### PR TITLE
Add Appendix A: Miscellaneous error message to User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -16,7 +16,7 @@
 
 1. Ensure you have Java `11` or above installed in your Computer.
 
-1. Download the latest `wedlog.jar` from [here](https://github.com/AY2324S1-CS2103T-F11-2/tp).
+1. Download the latest `wedlog.jar` from [here](https://github.com/AY2324S1-CS2103T-F11-2/tp/releases).
 
 1. Copy the file to the folder you want to use as the _home folder_ for your WedLog.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -201,3 +201,14 @@ Action     | Format, Examples
 **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **List**   | `list`
 **Help**   | `help`
+
+--------------------------------------------------------------------------------------------------------------------
+## Appendix A: Miscellaneous error messages
+
+User input is completely invalid (e.g. `abc` or `vsdf`):
+- Display error message "No such command exists."
+
+
+User input begins with `vendor` or `guest`, but does not include a valid command word (e.g. `vendor abc` or
+`guest adddd`):
+- Display error message "Please specify a command."

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -17,28 +17,16 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
 1. Ensure you have Java `11` or above installed in your Computer.
 
-1. Download the latest `addressbook.jar` from [here](https://github.com/se-edu/addressbook-level3/releases).
+1. Download the latest `wedlog.jar` from [here](https://github.com/AY2324S1-CS2103T-F11-2/tp).
 
-1. Copy the file to the folder you want to use as the _home folder_ for your AddressBook.
+1. Copy the file to the folder you want to use as the _home folder_ for your WedLog.
 
-1. Open a command terminal, `cd` into the folder you put the jar file in, and use the `java -jar addressbook.jar` command to run the application.<br>
+1. Open a command terminal, `cd` into the folder you put the jar file in, and use the `java -jar wedlog.jar` command to run the application.<br>
    A GUI similar to the below should appear in a few seconds. Note how the app contains some sample data.<br>
    ![Ui](images/Ui.png)
 
-1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window.<br>
-   Some example commands you can try:
-
-   * `list` : Lists all contacts.
-
-   * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01` : Adds a contact named `John Doe` to the Address Book.
-
-   * `delete 3` : Deletes the 3rd contact shown in the current list.
-
-   * `clear` : Deletes all contacts.
-
-   * `exit` : Exits the app.
-
-1. Refer to the [Features](#features) below for details of each command.
+1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window. 
+Refer to the [Features](#features) below for details of different command.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -26,7 +26,7 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
    ![Ui](images/Ui.png)
 
 1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window. 
-Refer to the [Features](#features) below for details of different command.
+Refer to the [Features](#features) below for details of each command.
 
 --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
The user guide does not specify expected behavior when WedLog is faced with erroneous inputs that do not fall under a specific command.

When users are faced with these behaviours, they may not understand the reason why.

Let's add a section that details the expected output for different types of input errors that are not tied to a specific command.