### PR TITLE
UG: Add `help`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -66,6 +66,17 @@ e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 </box>
 
 --------------------------------------------------------------------------------------------------------------------
+### Viewing help : `help`
+
+Shows a message explaining how to access the help page.
+
+```text
+help
+```
+
+Expected behaviour upon success:
+* Displays a link to the help page
+
 ### Adding a vendor : `vendor add`
 
 Adds a vendor to WedLog.
@@ -202,11 +213,12 @@ Expected behaviour upon failure:
 
 ## Command summary
 
-| Action                   | Format                                                             | Example                         |
-|--------------------------|:-------------------------------------------------------------------|---------------------------------|
-| **Add a vendor**         | `vendor add n/NAME [p/PHONE_NUMBER]`                               | `vendor add n/Betsy p/91234567` |
-| **Delete a vendor**      | `vendor delete INDEX`                                              | `vendor delete 2`               |
-| **View all guests**      | `guest list`                                                       |                                 |
-| **View specific guest**  | `guest view INDEX`                                                 | `guest view 1`                  |
-| **View all vendors**     | `vendor list`                                                      |                                 |
-| **View specific vendor** | `vendor view INDEX`                                                | `vendor view 1`                 |
+| Action                   | Format                               | Example                         |
+|--------------------------|:-------------------------------------|---------------------------------|
+| **View help**            | `help`                               |                                 |
+| **Add a vendor**         | `vendor add n/NAME [p/PHONE_NUMBER]` | `vendor add n/Betsy p/91234567` |
+| **Delete a vendor**      | `vendor delete INDEX`                | `vendor delete 2`               |
+| **View all guests**      | `guest list`                         |                                 |
+| **View specific guest**  | `guest view INDEX`                   | `guest view 1`                  |
+| **View all vendors**     | `vendor list`                        |                                 |
+| **View specific vendor** | `vendor view INDEX`                  | `vendor view 1`                 |


### PR DESCRIPTION
Currently, the user guide doesn't contain all v1.2 specific commands.

The user guide should cover the complete detailed description of the intended behavior of the product at v1.2.

Let's add the `help` command into the user guide. This partially addresses #8.