### PR TITLE
Model: Add `guest` and `vendor` methods

### DIFF
--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -16,12 +16,6 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
-    /** {@code Predicate} that always evaluate to true */
-    Predicate<Guest> PREDICATE_SHOW_ALL_GUESTS = unused -> true;
-
-    /** {@code Predicate} that always evaluate to true */
-    Predicate<Vendor> PREDICATE_SHOW_ALL_VENDORS = unused -> true;
-
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
@@ -148,7 +142,7 @@ public interface Model {
      * Updates the filter of the filtered guest list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredGuestList(Predicate<Guest> predicate);
+    void updateFilteredGuestList(Predicate<Person> predicate);
 
     /** Returns an unmodifiable view of the filtered vendor list */
     ObservableList<Vendor> getFilteredVendorList();
@@ -157,5 +151,5 @@ public interface Model {
      * Updates the filter of the filtered vendor list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredVendorList(Predicate<Vendor> predicate);
+    void updateFilteredVendorList(Predicate<Person> predicate);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,7 +5,9 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Guest;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Vendor;
 
 /**
  * The API of the Model component.
@@ -13,6 +15,12 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Guest> PREDICATE_SHOW_ALL_GUESTS = unused -> true;
+
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Vendor> PREDICATE_SHOW_ALL_VENDORS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -76,6 +84,54 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Returns true if a guest with the same identity as {@code guest} exists in the address book.
+     */
+    boolean hasGuest(Guest guest);
+
+    /**
+     * Deletes the given guest.
+     * The guest must exist in the address book.
+     */
+    void deleteGuest(Guest target);
+
+    /**
+     * Adds the given guest.
+     * {@code guest} must not already exist in the address book.
+     */
+    void addGuest(Guest guest);
+
+    /**
+     * Replaces the given guest {@code target} with {@code editedGuest}.
+     * {@code target} must exist in the address book.
+     * The guest identity of {@code editedGuest} must not be the same as another existing guest in the address book.
+     */
+    void setGuest(Guest target, Guest editedGuest);
+
+    /**
+     * Returns true if a vendor with the same identity as {@code vendor} exists in the address book.
+     */
+    boolean hasVendor(Vendor vendor);
+
+    /**
+     * Deletes the given vendor.
+     * The vendor must exist in the address book.
+     */
+    void deleteVendor(Vendor target);
+
+    /**
+     * Adds the given vendor.
+     * {@code vendor} must not already exist in the address book.
+     */
+    void addVendor(Vendor vendor);
+
+    /**
+     * Replaces the given vendor {@code target} with {@code editedVendor}.
+     * {@code target} must exist in the address book.
+     * The vendor identity of {@code editedVendor} must not be the same as another existing vendor in the address book.
+     */
+    void setVendor(Vendor target, Vendor editedVendor);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
@@ -84,4 +140,22 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /** Returns an unmodifiable view of the filtered guest list */
+    ObservableList<Guest> getFilteredGuestList();
+
+    /**
+     * Updates the filter of the filtered guest list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredGuestList(Predicate<Guest> predicate);
+
+    /** Returns an unmodifiable view of the filtered vendor list */
+    ObservableList<Vendor> getFilteredVendorList();
+
+    /**
+     * Updates the filter of the filtered vendor list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredVendorList(Predicate<Vendor> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,9 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Guest;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Vendor;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -22,6 +24,8 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Guest> filteredGuests;
+    private final FilteredList<Vendor> filteredVendors;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +38,8 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredGuests = new FilteredList<>(this.addressBook.getGuestList());
+        filteredVendors = new FilteredList<>(this.addressBook.getVendorList());
     }
 
     public ModelManager() {
@@ -111,6 +117,54 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    @Override
+    public boolean hasGuest(Guest guest) {
+        requireNonNull(guest);
+        return addressBook.hasGuest(guest);
+    }
+
+    @Override
+    public void deleteGuest(Guest target) {
+        addressBook.removeGuest(target);
+    }
+
+    @Override
+    public void addGuest(Guest guest) {
+        addressBook.addGuest(guest);
+        updateFilteredGuestList(PREDICATE_SHOW_ALL_GUESTS);
+    }
+
+    @Override
+    public void setGuest(Guest target, Guest editedGuest) {
+        requireAllNonNull(target, editedGuest);
+
+        addressBook.setGuest(target, editedGuest);
+    }
+
+    @Override
+    public boolean hasVendor(Vendor vendor) {
+        requireNonNull(vendor);
+        return addressBook.hasVendor(vendor);
+    }
+
+    @Override
+    public void deleteVendor(Vendor target) {
+        addressBook.removeVendor(target);
+    }
+
+    @Override
+    public void addVendor(Vendor vendor) {
+        addressBook.addVendor(vendor);
+        updateFilteredVendorList(PREDICATE_SHOW_ALL_VENDORS);
+    }
+
+    @Override
+    public void setVendor(Vendor target, Vendor editedVendor) {
+        requireAllNonNull(target, editedVendor);
+
+        addressBook.setVendor(target, editedVendor);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**
@@ -128,6 +182,36 @@ public class ModelManager implements Model {
         filteredPersons.setPredicate(predicate);
     }
 
+    /**
+     * Returns an unmodifiable view of the list of {@code Guest} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Guest> getFilteredGuestList() {
+        return filteredGuests;
+    }
+
+    @Override
+    public void updateFilteredGuestList(Predicate<Guest> predicate) {
+        requireNonNull(predicate);
+        filteredGuests.setPredicate(predicate);
+    }
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Vendor} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Vendor> getFilteredVendorList() {
+        return filteredVendors;
+    }
+
+    @Override
+    public void updateFilteredVendorList(Predicate<Vendor> predicate) {
+        requireNonNull(predicate);
+        filteredVendors.setPredicate(predicate);
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -142,7 +226,9 @@ public class ModelManager implements Model {
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredPersons.equals(otherModelManager.filteredPersons);
+                && filteredPersons.equals(otherModelManager.filteredPersons)
+                && filteredGuests.equals(otherModelManager.filteredGuests)
+                && filteredVendors.equals(otherModelManager.filteredVendors);
     }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -131,7 +131,7 @@ public class ModelManager implements Model {
     @Override
     public void addGuest(Guest guest) {
         addressBook.addGuest(guest);
-        updateFilteredGuestList(PREDICATE_SHOW_ALL_GUESTS);
+        updateFilteredGuestList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
@@ -155,7 +155,7 @@ public class ModelManager implements Model {
     @Override
     public void addVendor(Vendor vendor) {
         addressBook.addVendor(vendor);
-        updateFilteredVendorList(PREDICATE_SHOW_ALL_VENDORS);
+        updateFilteredVendorList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
@@ -192,7 +192,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredGuestList(Predicate<Guest> predicate) {
+    public void updateFilteredGuestList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredGuests.setPredicate(predicate);
     }
@@ -207,7 +207,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredVendorList(Predicate<Vendor> predicate) {
+    public void updateFilteredVendorList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredVendors.setPredicate(predicate);
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -206,7 +206,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updateFilteredGuestList(Predicate<Guest> predicate) {
+        public void updateFilteredGuestList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -216,7 +216,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updateFilteredVendorList(Predicate<Vendor> predicate) {
+        public void updateFilteredVendorList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,7 +22,9 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Guest;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Vendor;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -149,12 +151,72 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasGuest(Guest guest) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteGuest(Guest target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addGuest(Guest guest) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuest(Guest target, Guest editedGuest) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasVendor(Vendor vendor) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteVendor(Vendor target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addVendor(Vendor vendor) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setVendor(Vendor target, Vendor editedVendor) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Guest> getFilteredGuestList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredGuestList(Predicate<Guest> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Vendor> getFilteredVendorList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredVendorList(Predicate<Vendor> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -359,7 +359,11 @@ public class ModelManagerTest {
 
     @Test
     public void equals() {
-        AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
+        AddressBook addressBook = new AddressBookBuilder()
+                .withPerson(ALICE).withPerson(BENSON)
+                .withGuest(GEORGE).withGuest(GREG)
+                .withVendor(ANNE).withVendor(BRYAN)
+                .build();
         AddressBook differentAddressBook = new AddressBook();
         UserPrefs userPrefs = new UserPrefs();
 
@@ -380,13 +384,29 @@ public class ModelManagerTest {
         // different addressBook -> returns false
         assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
 
-        // different filteredList -> returns false
-        String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        // different person filteredList -> returns false
+        String[] personKeywords = ALICE.getName().fullName.split("\\s+");
+        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(personKeywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        // different guest filteredList -> returns false
+        String[] guestKeywords = GEORGE.getName().fullName.split("\\s+");
+        modelManager.updateFilteredGuestList(new NameContainsKeywordsPredicate(Arrays.asList(guestKeywords)));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+
+        // resets modelManager to initial state for upcoming tests
+        modelManager.updateFilteredGuestList(PREDICATE_SHOW_ALL_PERSONS);
+
+        // different vendor filteredList -> returns false
+        String[] vendorKeywords = ANNE.getName().fullName.split("\\s+");
+        modelManager.updateFilteredVendorList(new NameContainsKeywordsPredicate(Arrays.asList(vendorKeywords)));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+
+        // resets modelManager to initial state for upcoming tests
+        modelManager.updateFilteredVendorList(PREDICATE_SHOW_ALL_PERSONS);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -3,12 +3,16 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalGuests.GEORGE;
+import static seedu.address.testutil.TypicalGuests.GREG;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalVendors.ANNE;
+import static seedu.address.testutil.TypicalVendors.BRYAN;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -17,8 +21,20 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Guest;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Vendor;
+import seedu.address.model.person.exceptions.DuplicateGuestException;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.DuplicateVendorException;
+import seedu.address.model.person.exceptions.GuestNotFoundException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.model.person.exceptions.VendorNotFoundException;
 import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.GuestBuilder;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.VendorBuilder;
 
 public class ModelManagerTest {
 
@@ -91,6 +107,74 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void deletePerson_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.deletePerson(null));
+    }
+
+    @Test
+    public void deletePerson_personDoesNotExist_throwsPersonNotFoundException() {
+        assertThrows(PersonNotFoundException.class, () -> modelManager.deletePerson(ALICE));
+    }
+
+    @Test
+    public void deletePerson_existingPerson_deletesPerson() {
+        modelManager.addPerson(ALICE);
+        modelManager.deletePerson(ALICE);
+        ModelManager expectedModelManager = new ModelManager();
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setPerson_nullTargetPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setPerson(null, ALICE));
+    }
+
+    @Test
+    public void setPerson_nullEditedPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setPerson(ALICE, null));
+    }
+
+    @Test
+    public void setPerson_targetPersonDoesNotExist_throwsNullPointerException() {
+        assertThrows(PersonNotFoundException.class, () -> modelManager.setPerson(ALICE, ALICE));
+    }
+
+    @Test
+    public void setPerson_editedPersonIsSamePerson_success() {
+        modelManager.addPerson(ALICE);
+        modelManager.setPerson(ALICE, ALICE);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addPerson(ALICE);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setPerson_editedPersonHasSameIdentity_success() {
+        modelManager.addPerson(ALICE);
+        Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
+        modelManager.setPerson(ALICE, editedAlice);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addPerson(editedAlice);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setPerson_editedPersonHasDifferentIdentity_success() {
+        modelManager.addPerson(ALICE);
+        modelManager.setPerson(ALICE, BOB);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addPerson(BOB);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setPerson_editedPersonIsNonUnique_throwsDuplicatePersonException() {
+        modelManager.addPerson(ALICE);
+        modelManager.addPerson(BOB);
+        assertThrows(DuplicatePersonException.class, () -> modelManager.setPerson(ALICE, BOB));
+    }
+
+    @Test
     public void hasGuest_nullGuest_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> modelManager.hasGuest(null));
     }
@@ -107,6 +191,74 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void deleteGuest_nullGuest_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.deleteGuest(null));
+    }
+
+    @Test
+    public void deleteGuest_vendorDoesNotExist_throwsGuestNotFoundException() {
+        assertThrows(GuestNotFoundException.class, () -> modelManager.deleteGuest(GEORGE));
+    }
+
+    @Test
+    public void deleteGuest_existingGuest_deletesGuest() {
+        modelManager.addGuest(GEORGE);
+        modelManager.deleteGuest(GEORGE);
+        ModelManager expectedModelManager = new ModelManager();
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setGuest_nullTargetGuest_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setGuest(null, GEORGE));
+    }
+
+    @Test
+    public void setGuest_nullEditedGuest_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setGuest(GEORGE, null));
+    }
+
+    @Test
+    public void setGuest_targetGuestDoesNotExist_throwsNullPointerException() {
+        assertThrows(GuestNotFoundException.class, () -> modelManager.setGuest(GEORGE, GEORGE));
+    }
+
+    @Test
+    public void setGuest_editedGuestIsSameGuest_success() {
+        modelManager.addGuest(GEORGE);
+        modelManager.setGuest(GEORGE, GEORGE);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addGuest(GEORGE);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setGuest_editedGuestHasSameIdentity_success() {
+        modelManager.addGuest(GEORGE);
+        Guest editedGeorge = new GuestBuilder(GEORGE).withAddress(VALID_ADDRESS_BOB).build();
+        modelManager.setGuest(GEORGE, editedGeorge);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addGuest(editedGeorge);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setGuest_editedGuestHasDifferentIdentity_success() {
+        modelManager.addGuest(GEORGE);
+        modelManager.setGuest(GEORGE, GREG);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addGuest(GREG);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setGuest_editedGuestIsNonUnique_throwsDuplicateGuestException() {
+        modelManager.addGuest(GEORGE);
+        modelManager.addGuest(GREG);
+        assertThrows(DuplicateGuestException.class, () -> modelManager.setGuest(GEORGE, GREG));
+    }
+
+    @Test
     public void hasVendor_nullVendor_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> modelManager.hasVendor(null));
     }
@@ -120,6 +272,74 @@ public class ModelManagerTest {
     public void hasVendor_vendorInAddressBook_returnsTrue() {
         modelManager.addVendor(ANNE);
         assertTrue(modelManager.hasVendor(ANNE));
+    }
+
+    @Test
+    public void deleteVendor_nullVendor_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.deleteVendor(null));
+    }
+
+    @Test
+    public void deleteVendor_vendorDoesNotExist_throwsVendorNotFoundException() {
+        assertThrows(VendorNotFoundException.class, () -> modelManager.deleteVendor(ANNE));
+    }
+
+    @Test
+    public void deleteVendor_existingVendor_deletesVendor() {
+        modelManager.addVendor(ANNE);
+        modelManager.deleteVendor(ANNE);
+        ModelManager expectedModelManager = new ModelManager();
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setVendor_nullTargetVendor_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setVendor(null, ANNE));
+    }
+
+    @Test
+    public void setVendor_nullEditedVendor_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setVendor(ANNE, null));
+    }
+
+    @Test
+    public void setVendor_targetVendorDoesNotExist_throwsNullPointerException() {
+        assertThrows(VendorNotFoundException.class, () -> modelManager.setVendor(ANNE, ANNE));
+    }
+
+    @Test
+    public void setVendor_editedVendorIsSameVendor_success() {
+        modelManager.addVendor(ANNE);
+        modelManager.setVendor(ANNE, ANNE);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addVendor(ANNE);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setVendor_editedVendorHasSameIdentity_success() {
+        modelManager.addVendor(ANNE);
+        Vendor editedAnne = new VendorBuilder(ANNE).withAddress(VALID_ADDRESS_BOB).build();
+        modelManager.setVendor(ANNE, editedAnne);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addVendor(editedAnne);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setVendor_editedVendorHasDifferentIdentity_success() {
+        modelManager.addVendor(ANNE);
+        modelManager.setVendor(ANNE, BRYAN);
+        ModelManager expectedModelManager = new ModelManager();
+        expectedModelManager.addVendor(BRYAN);
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void setVendor_editedVendorIsNonUnique_throwsDuplicateVendorException() {
+        modelManager.addVendor(ANNE);
+        modelManager.addVendor(BRYAN);
+        assertThrows(DuplicateVendorException.class, () -> modelManager.setVendor(ANNE, BRYAN));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalGuests.GEORGE;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalVendors.ANNE;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -89,8 +91,50 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasGuest_nullGuest_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasGuest(null));
+    }
+
+    @Test
+    public void hasGuest_guestNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasGuest(GEORGE));
+    }
+
+    @Test
+    public void hasGuest_guestInAddressBook_returnsTrue() {
+        modelManager.addGuest(GEORGE);
+        assertTrue(modelManager.hasGuest(GEORGE));
+    }
+
+    @Test
+    public void hasVendor_nullVendor_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasVendor(null));
+    }
+
+    @Test
+    public void hasVendor_vendorNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasVendor(ANNE));
+    }
+
+    @Test
+    public void hasVendor_vendorInAddressBook_returnsTrue() {
+        modelManager.addVendor(ANNE);
+        assertTrue(modelManager.hasVendor(ANNE));
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void getFilteredGuestList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredGuestList().remove(0));
+    }
+
+    @Test
+    public void getFilteredVendorList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredVendorList().remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/AddressBookBuilder.java
@@ -1,7 +1,9 @@
 package seedu.address.testutil;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.person.Guest;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Vendor;
 
 /**
  * A utility class to help with building Addressbook objects.
@@ -25,6 +27,22 @@ public class AddressBookBuilder {
      */
     public AddressBookBuilder withPerson(Person person) {
         addressBook.addPerson(person);
+        return this;
+    }
+
+    /**
+     * Adds a new {@code Guest} to the {@code AddressBook} that we are building.
+     */
+    public AddressBookBuilder withGuest(Guest guest) {
+        addressBook.addGuest(guest);
+        return this;
+    }
+
+    /**
+     * Adds a new {@code Vendor} to the {@code AddressBook} that we are building.
+     */
+    public AddressBookBuilder withVendor(Vendor vendor) {
+        addressBook.addVendor(vendor);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalGuests.java
+++ b/src/test/java/seedu/address/testutil/TypicalGuests.java
@@ -40,13 +40,13 @@ public class TypicalGuests {
             .withEmail("gabkurz@example.com").withAddress("wall street")
             .withRsvpStatus("unknown").withDietaryRequirements("vegetarian")
             .build();
-    public static final Guest GEORGE = new GuestBuilder().withName("George Meier").withPhone("87652533")
+    public static final Guest GEORGE = new GuestBuilder().withName("George Tan").withPhone("87652533")
             .withEmail("georgemeier@example.com").withAddress("10th street")
             .withRsvpStatus("yes").withDietaryRequirements("no beef")
             .withTags("friends").build();
 
     // Manually added
-    public static final Guest GIDEON = new GuestBuilder().withName("Gideon Meier").withPhone("8482424")
+    public static final Guest GIDEON = new GuestBuilder().withName("Gideon Lim").withPhone("8482424")
             .withEmail("gideon@example.com").withAddress("little india")
             .withRsvpStatus("unknown").withDietaryRequirements("none")
             .build();


### PR DESCRIPTION
The model lacks methods to add, remove, set and display guests and vendors. Fixes #28.

Let's
* Add the methods to Model to enforce the need for such methods
* Add the methods to ModelManager to implement the methods
* Add the relevant test methods for the new methods
* Modify AddCommandTest.ModelStub with modified Model requirements

The following guest methods (and their corresponding person/vendor methods) have been added to tests:
- [x] `hasGuest`
- [x] `deleteGuest`
- [x] `setGuest`
- [x] `getFilteredGuestList`
- [x] `equals`