### PR TITLE
Implement `guest delete`

### DIFF
--- a/src/main/java/wedlog/address/logic/Messages.java
+++ b/src/main/java/wedlog/address/logic/Messages.java
@@ -15,6 +15,8 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_GUEST_DISPLAYED_INDEX = "The guest index provided is invalid";
+
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/wedlog/address/logic/commands/GuestAddCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestAddCommand.java
@@ -8,11 +8,11 @@ import static wedlog.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_RSVP;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static wedlog.address.logic.parser.GuestCommandParser.GUEST_COMMAND_WORD;
 
 import wedlog.address.commons.util.ToStringBuilder;
 import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
-import wedlog.address.logic.parser.GuestCommandParser;
 import wedlog.address.model.Model;
 import wedlog.address.model.person.Guest;
 
@@ -22,7 +22,7 @@ import wedlog.address.model.person.Guest;
 public class GuestAddCommand extends Command {
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = GuestCommandParser.GUEST_COMMAND_WORD + " " + COMMAND_WORD
+    public static final String MESSAGE_USAGE = GUEST_COMMAND_WORD + " " + COMMAND_WORD
             + ": Adds a guest to the address book. "
             + "Compulsory Parameters: "
             + PREFIX_NAME + "NAME "
@@ -31,7 +31,7 @@ public class GuestAddCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + GuestCommandParser.GUEST_COMMAND_WORD + " " + COMMAND_WORD + " "
+            + "Example: " + GUEST_COMMAND_WORD + " " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "

--- a/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
@@ -58,4 +58,11 @@ public class GuestDeleteCommand extends Command {
         GuestDeleteCommand otherGuestDeleteCommand = (GuestDeleteCommand) other;
         return targetIndex.equals(otherGuestDeleteCommand.targetIndex);
     }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
 }

--- a/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
@@ -1,6 +1,7 @@
 package wedlog.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static wedlog.address.logic.parser.GuestCommandParser.GUEST_COMMAND_WORD;
 
 import java.util.List;
 
@@ -15,12 +16,12 @@ import wedlog.address.model.person.Guest;
  * Deletes a Guest from the address book.
  */
 public class GuestDeleteCommand extends Command {
-    public static final String COMMAND_WORD = "guest delete";
+    public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = GUEST_COMMAND_WORD + " " + COMMAND_WORD
             + ": Deletes the guest identified by the index number used in the displayed guest list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Example: " + GUEST_COMMAND_WORD + " " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_GUEST_SUCCESS = "Deleted Guest: %1$s";
 

--- a/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
@@ -15,7 +15,7 @@ import wedlog.address.model.person.Guest;
  * Deletes a Guest from the address book.
  */
 public class GuestDeleteCommand extends Command {
-    public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD = "guest delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the guest identified by the index number used in the displayed guest list.\n"

--- a/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
@@ -10,7 +10,6 @@ import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
 import wedlog.address.model.Model;
 import wedlog.address.model.person.Guest;
-import wedlog.address.model.person.Person;
 
 /**
  * Deletes a Guest from the address book.
@@ -43,5 +42,20 @@ public class GuestDeleteCommand extends Command {
         Guest guestToDelete = lastShownGuestList.get(targetIndex.getZeroBased());
         model.deleteGuest(guestToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_GUEST_SUCCESS, Messages.format(guestToDelete)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof GuestDeleteCommand)) {
+            return false;
+        }
+
+        GuestDeleteCommand otherGuestDeleteCommand = (GuestDeleteCommand) other;
+        return targetIndex.equals(otherGuestDeleteCommand.targetIndex);
     }
 }

--- a/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
@@ -1,8 +1,16 @@
 package wedlog.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import wedlog.address.commons.core.index.Index;
+import wedlog.address.commons.util.ToStringBuilder;
+import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
 import wedlog.address.model.Model;
+import wedlog.address.model.person.Guest;
+import wedlog.address.model.person.Person;
 
 /**
  * Deletes a Guest from the address book.
@@ -17,15 +25,23 @@ public class GuestDeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_GUEST_SUCCESS = "Deleted Guest: %1$s";
 
-    // private final Index targetIndex;
+    private final Index targetIndex;
 
     public GuestDeleteCommand(Index targetIndex) {
-        // temporary empty constructor
-        // this.targetIndex = targetIndex;
+        this.targetIndex = targetIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("Command not created yet, wait for evolve for better testing");
+        requireNonNull(model);
+        List<Guest> lastShownGuestList = model.getFilteredGuestList();
+
+        if (targetIndex.getZeroBased() >= lastShownGuestList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Guest guestToDelete = lastShownGuestList.get(targetIndex.getZeroBased());
+        model.deleteGuest(guestToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_GUEST_SUCCESS, Messages.format(guestToDelete)));
     }
 }

--- a/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
@@ -36,7 +36,7 @@ public class GuestDeleteCommand extends Command {
         List<Guest> lastShownGuestList = model.getFilteredGuestList();
 
         if (targetIndex.getZeroBased() >= lastShownGuestList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_GUEST_DISPLAYED_INDEX);
         }
 
         Guest guestToDelete = lastShownGuestList.get(targetIndex.getZeroBased());

--- a/src/main/java/wedlog/address/logic/parser/GuestDeleteCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/GuestDeleteCommandParser.java
@@ -6,11 +6,11 @@ import wedlog.address.commons.core.index.Index;
 import wedlog.address.logic.commands.GuestDeleteCommand;
 import wedlog.address.logic.parser.exceptions.ParseException;
 
-
 /**
  * Parses user input specifically for GuestDelete commands.
  */
 public class GuestDeleteCommandParser implements Parser<GuestDeleteCommand> {
+
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.

--- a/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
@@ -17,6 +17,7 @@ import wedlog.address.commons.core.index.Index;
 import wedlog.address.logic.commands.exceptions.CommandException;
 import wedlog.address.model.AddressBook;
 import wedlog.address.model.Model;
+import wedlog.address.model.person.Guest;
 import wedlog.address.model.person.NameContainsKeywordsPredicate;
 import wedlog.address.model.person.Person;
 import wedlog.address.testutil.EditPersonDescriptorBuilder;
@@ -115,6 +116,7 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
@@ -129,4 +131,17 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered guest list to show only the guest at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showGuestAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredGuestList().size());
+
+        Guest guest = model.getFilteredGuestList().get(targetIndex.getZeroBased());
+        final String[] splitName = guest.getName().fullName.split("\\s+");
+        model.updateFilteredGuestList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredGuestList().size());
+    }
 }

--- a/src/test/java/wedlog/address/logic/commands/GuestDeleteCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/GuestDeleteCommandTest.java
@@ -1,0 +1,120 @@
+package wedlog.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static wedlog.address.logic.commands.CommandTestUtil.showGuestAtIndex;
+import static wedlog.address.testutil.TypicalGuests.getTypicalAddressBook;
+import static wedlog.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static wedlog.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import wedlog.address.commons.core.index.Index;
+import wedlog.address.logic.Messages;
+import wedlog.address.model.Model;
+import wedlog.address.model.ModelManager;
+import wedlog.address.model.UserPrefs;
+import wedlog.address.model.person.Guest;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code GuestDeleteCommand}.
+ */
+public class GuestDeleteCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredGuestList_success() {
+        Guest guestToDelete = model.getFilteredGuestList().get(INDEX_FIRST_PERSON.getZeroBased());
+        GuestDeleteCommand guestDeleteCommand = new GuestDeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(GuestDeleteCommand.MESSAGE_DELETE_GUEST_SUCCESS,
+                Messages.format(guestToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteGuest(guestToDelete);
+
+        assertCommandSuccess(guestDeleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredGuestList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredGuestList().size() + 1);
+        GuestDeleteCommand guestDeleteCommand = new GuestDeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(guestDeleteCommand, model, Messages.MESSAGE_INVALID_GUEST_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredGuestList_success() {
+        showGuestAtIndex(model, INDEX_FIRST_PERSON);
+
+        Guest guestToDelete = model.getFilteredGuestList().get(INDEX_FIRST_PERSON.getZeroBased());
+        GuestDeleteCommand guestDeleteCommand = new GuestDeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(GuestDeleteCommand.MESSAGE_DELETE_GUEST_SUCCESS,
+                Messages.format(guestToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteGuest(guestToDelete);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(guestDeleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredGuestList_throwsCommandException() {
+        showGuestAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getGuestList().size());
+
+        GuestDeleteCommand guestDeleteCommand = new GuestDeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(guestDeleteCommand, model, Messages.MESSAGE_INVALID_GUEST_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        GuestDeleteCommand guestDeleteFirstCommand = new GuestDeleteCommand(INDEX_FIRST_PERSON);
+        GuestDeleteCommand guestDeleteSecondCommand = new GuestDeleteCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(guestDeleteFirstCommand.equals(guestDeleteFirstCommand));
+
+        // same values -> returns true
+        GuestDeleteCommand guestDeleteFirstCommandCopy = new GuestDeleteCommand(INDEX_FIRST_PERSON);
+        assertTrue(guestDeleteFirstCommand.equals(guestDeleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(guestDeleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(guestDeleteFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(guestDeleteFirstCommand.equals(guestDeleteSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        GuestDeleteCommand guestDeleteCommand = new GuestDeleteCommand(targetIndex);
+        String expected = GuestDeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, guestDeleteCommand.toString());
+    }
+
+    /**
+     * Updates {@code model}'s filtered guest list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredGuestList(p -> false);
+
+        assertTrue(model.getFilteredGuestList().isEmpty());
+    }
+}

--- a/src/test/java/wedlog/address/logic/parser/GuestDeleteCommandParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/GuestDeleteCommandParserTest.java
@@ -1,8 +1,9 @@
 package wedlog.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static wedlog.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static wedlog.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static wedlog.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static wedlog.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,10 +23,7 @@ public class GuestDeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsGuestDeleteCommand() throws ParseException {
-        assertTrue(parser.parse("1") instanceof GuestDeleteCommand);
-
-        // code below invalid due to un-evolved GuestDeleteCommand (equals method)
-        // assertParseSuccess(parser, "1", new GuestDeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new GuestDeleteCommand(INDEX_FIRST_PERSON));
     }
 
     @Test


### PR DESCRIPTION
Currently, the GuestDeleteCommand throws an exception when it is executed.

Let's implement the logic of executing a GuestDeleteCommand.
  - update constructor in GuestDeleteCommand
  - update execute method in GuestDeleteCommand
  - add equals method in GuestDeleteCommand
  - add toString method in GuestDeleteCommand
  - add MESSAGE_INVALID_GUEST_DISPLAYED_INDEX message in Messages
  - create GuestDeleteCommandTest class and add tests
  - add showGuestAtIndex method in CommandTestUtil

This will allow users to delete guests from the guest list by specifying the index.

Resolves #54.