### PR TITLE
Implement `vendor delete`

### DIFF
--- a/src/main/java/wedlog/address/logic/Messages.java
+++ b/src/main/java/wedlog/address/logic/Messages.java
@@ -15,6 +15,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX = "The vendor index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
@@ -6,11 +6,11 @@ import static wedlog.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static wedlog.address.logic.parser.VendorCommandParser.VENDOR_COMMAND_WORD;
 
 import wedlog.address.commons.util.ToStringBuilder;
 import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
-import wedlog.address.logic.parser.VendorCommandParser;
 import wedlog.address.model.Model;
 import wedlog.address.model.person.Vendor;
 
@@ -20,7 +20,7 @@ import wedlog.address.model.person.Vendor;
 public class VendorAddCommand extends Command {
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD
+    public static final String MESSAGE_USAGE = VENDOR_COMMAND_WORD + " " + COMMAND_WORD
             + ": Adds a vendor to the address book. "
             + "Compulsory Parameters: "
             + PREFIX_NAME + "NAME "
@@ -29,7 +29,7 @@ public class VendorAddCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD + " "
+            + "Example: " + VENDOR_COMMAND_WORD + " " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "

--- a/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
@@ -1,13 +1,19 @@
 package wedlog.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import wedlog.address.commons.core.index.Index;
+import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
 import wedlog.address.model.Model;
+import wedlog.address.model.person.Vendor;
 
 /**
  * Deletes a Vendor from the address book.
  */
-public class VendorDeleteCommand extends Command { // this is still the old DeleteCommand Implementation
+public class VendorDeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -17,13 +23,20 @@ public class VendorDeleteCommand extends Command { // this is still the old Dele
 
     public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
 
-    // private final Index targetIndex;
+    private final Index targetIndex;
 
     public VendorDeleteCommand(Index targetIndex) {
-        // temporary empty constructor
-        // this.targetIndex = targetIndex;
+        this.targetIndex = targetIndex;
     }
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("Command not created yet, wait for evolve for better testing");
-    }
+        requireNonNull(model);
+        List<Vendor> lastShownVendorList = model.getFilteredVendorList();
+
+        if (targetIndex.getZeroBased() >= lastShownVendorList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Vendor vendorToDelete = lastShownVendorList.get(targetIndex.getZeroBased());
+        model.deleteVendor(vendorToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_SUCCESS, Messages.format(vendorToDelete)));    }
 }

--- a/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
@@ -8,6 +8,7 @@ import wedlog.address.commons.core.index.Index;
 import wedlog.address.commons.util.ToStringBuilder;
 import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
+import wedlog.address.logic.parser.VendorCommandParser;
 import wedlog.address.model.Model;
 import wedlog.address.model.person.Vendor;
 
@@ -17,10 +18,10 @@ import wedlog.address.model.person.Vendor;
 public class VendorDeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD
             + ": Deletes the vendor identified by the index number used in the displayed vendor list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Example: " + VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
 

--- a/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
@@ -1,6 +1,7 @@
 package wedlog.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static wedlog.address.logic.parser.VendorCommandParser.VENDOR_COMMAND_WORD;
 
 import java.util.List;
 
@@ -8,7 +9,6 @@ import wedlog.address.commons.core.index.Index;
 import wedlog.address.commons.util.ToStringBuilder;
 import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
-import wedlog.address.logic.parser.VendorCommandParser;
 import wedlog.address.model.Model;
 import wedlog.address.model.person.Vendor;
 
@@ -18,10 +18,10 @@ import wedlog.address.model.person.Vendor;
 public class VendorDeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD
+    public static final String MESSAGE_USAGE = VENDOR_COMMAND_WORD + " " + COMMAND_WORD
             + ": Deletes the vendor identified by the index number used in the displayed vendor list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD + " 1";
+            + "Example: " + VENDOR_COMMAND_WORD + " " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
 

--- a/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
@@ -28,6 +28,8 @@ public class VendorDeleteCommand extends Command {
     public VendorDeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
+
+    @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Vendor> lastShownVendorList = model.getFilteredVendorList();
@@ -38,5 +40,21 @@ public class VendorDeleteCommand extends Command {
 
         Vendor vendorToDelete = lastShownVendorList.get(targetIndex.getZeroBased());
         model.deleteVendor(vendorToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_SUCCESS, Messages.format(vendorToDelete)));    }
+        return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_SUCCESS, Messages.format(vendorToDelete)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof VendorDeleteCommand)) {
+            return false;
+        }
+
+        VendorDeleteCommand otherVendorDeleteCommand = (VendorDeleteCommand) other;
+        return targetIndex.equals(otherVendorDeleteCommand.targetIndex);
+    }
 }

--- a/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import wedlog.address.commons.core.index.Index;
+import wedlog.address.commons.util.ToStringBuilder;
 import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
 import wedlog.address.model.Model;
@@ -56,5 +57,12 @@ public class VendorDeleteCommand extends Command {
 
         VendorDeleteCommand otherVendorDeleteCommand = (VendorDeleteCommand) other;
         return targetIndex.equals(otherVendorDeleteCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
     }
 }

--- a/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
@@ -36,7 +36,7 @@ public class VendorDeleteCommand extends Command {
         List<Vendor> lastShownVendorList = model.getFilteredVendorList();
 
         if (targetIndex.getZeroBased() >= lastShownVendorList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
         }
 
         Vendor vendorToDelete = lastShownVendorList.get(targetIndex.getZeroBased());

--- a/src/main/java/wedlog/address/logic/parser/VendorCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/VendorCommandParser.java
@@ -24,7 +24,7 @@ public class VendorCommandParser {
     /**
      * Used for initial separation of command word and args.
      */
-    public static final String COMMAND_WORD = "vendor";
+    public static final String VENDOR_COMMAND_WORD = "vendor";
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 

--- a/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
@@ -19,6 +19,7 @@ import wedlog.address.model.AddressBook;
 import wedlog.address.model.Model;
 import wedlog.address.model.person.NameContainsKeywordsPredicate;
 import wedlog.address.model.person.Person;
+import wedlog.address.model.person.Vendor;
 import wedlog.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -129,4 +130,17 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showVendorAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredVendorList().size());
+
+        Vendor vendor = model.getFilteredVendorList().get(targetIndex.getZeroBased());
+        final String[] splitName = vendor.getName().fullName.split("\\s+");
+        model.updateFilteredVendorList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredVendorList().size());
+    }
 }

--- a/src/test/java/wedlog/address/logic/commands/VendorDeleteCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/VendorDeleteCommandTest.java
@@ -1,0 +1,120 @@
+package wedlog.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static wedlog.address.logic.commands.CommandTestUtil.showVendorAtIndex;
+import static wedlog.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static wedlog.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static wedlog.address.testutil.TypicalVendors.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import wedlog.address.commons.core.index.Index;
+import wedlog.address.logic.Messages;
+import wedlog.address.model.Model;
+import wedlog.address.model.ModelManager;
+import wedlog.address.model.UserPrefs;
+import wedlog.address.model.person.Vendor;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code GuestDeleteCommand}.
+ */
+public class VendorDeleteCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredVendorList_success() {
+        Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_PERSON.getZeroBased());
+        VendorDeleteCommand vendorDeleteCommand = new VendorDeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(VendorDeleteCommand.MESSAGE_DELETE_VENDOR_SUCCESS,
+                Messages.format(vendorToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteVendor(vendorToDelete);
+
+        assertCommandSuccess(vendorDeleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredVendorList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredVendorList().size() + 1);
+        VendorDeleteCommand vendorDeleteCommand = new VendorDeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(vendorDeleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredVendorList_success() {
+        showVendorAtIndex(model, INDEX_FIRST_PERSON);
+
+        Vendor vendorToDelete = model.getFilteredVendorList().get(INDEX_FIRST_PERSON.getZeroBased());
+        VendorDeleteCommand vendorDeleteCommand = new VendorDeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(VendorDeleteCommand.MESSAGE_DELETE_VENDOR_SUCCESS,
+                Messages.format(vendorToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteVendor(vendorToDelete);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(vendorDeleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredVendorList_throwsCommandException() {
+        showVendorAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getVendorList().size());
+
+        VendorDeleteCommand vendorDeleteCommand = new VendorDeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(vendorDeleteCommand, model, Messages.MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        VendorDeleteCommand vendorDeleteFirstCommand = new VendorDeleteCommand(INDEX_FIRST_PERSON);
+        VendorDeleteCommand vendorDeleteSecondCommand = new VendorDeleteCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(vendorDeleteFirstCommand.equals(vendorDeleteFirstCommand));
+
+        // same values -> returns true
+        VendorDeleteCommand vendorDeleteFirstCommandCopy = new VendorDeleteCommand(INDEX_FIRST_PERSON);
+        assertTrue(vendorDeleteFirstCommand.equals(vendorDeleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(vendorDeleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(vendorDeleteFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(vendorDeleteFirstCommand.equals(vendorDeleteSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        VendorDeleteCommand vendorDeleteCommand = new VendorDeleteCommand(targetIndex);
+        String expected = VendorDeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, vendorDeleteCommand.toString());
+    }
+
+    /**
+     * Updates {@code model}'s filtered guest list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredVendorList(p -> false);
+
+        assertTrue(model.getFilteredVendorList().isEmpty());
+    }
+}


### PR DESCRIPTION
Currently, the VendorDeleteCommand throws an exception when it is executed.

Let's implement the logic of executing a VendorDeleteCommand.

  - update constructor in VendorDeleteCommand
  - update execute method in VendorDeleteCommand
  - add equals method in VendorDeleteCommand
  - add toString method in VendorDeleteCommand
  - add MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX message in Messages
  - create VendorDeleteCommand class and add tests
  - add showVendorAtIndex method in CommandTestUtil

This will allow users to delete vendors from the vendor list by specifying the index.

Resolves #60.