### PR TITLE
Implement `vendor add`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -51,6 +51,7 @@ e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` i
 e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
+
 </box>
 
 --------------------------------------------------------------------------------------------------------------------
@@ -149,15 +150,45 @@ Expected behaviour upon failure:
 Adds a vendor to WedLog.
 
 ```text
-vendor add n/NAME [p/PHONE_NUMBER]
+vendor add n/NAME [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG...]
 ```
+A guest must have the following tags: `n/NAME`
 
-Acceptable values for PHONE_NUMBER:
+The following tags are optional: `p/PHONE_NUMBER e/EMAIL a/ADDRESS r/RSVP_STATUS d/DIETARY_REQUIREMENTS t/TAG...`
+
+Acceptable values for `n/NAME`:
+- Alphanumeric word with or without spaces
+
+Acceptable values for `n/PHONE_NUMBER`:
 - Numbers with no spaces or special characters
+
+Acceptable values for `e/EMAIL`:
+- `local-part@domain`
+  - the `local-part` must:
+    - contain alphanumeric characters and these special characters, excluding the parentheses (+_.-)
+    - not start or end with any special characters
+  - the `domain` must:
+    - consist of domain labels separated by periods
+    - end with a domain label at least 2 characters long
+    - have each domain label start and end with alphanumeric characters
+    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any
+
+Acceptable values for `a/ADDRESS`:
+- Word with or without spaces
+
+Acceptable values for `t/tag`:
+- Alphanumeric word without spaces
+
+>Tips:
+><br>
+>- Parameters can be in any order
+   ><br>
+>- A guest can have any number of tags (including 0)
 
 Examples:
 - `vendor add n/Betsy Crowe`
-- `vendor add n/John Doe Floral p/91234567`
+- `vendor add n/John Doe p/91234567`
+- `vendor add n/John Doe p/91234567 e/johndflowers@email.com a/123 Flower Lane t/florist t/photographer`
 
 Expected behaviour upon success:
 - Adds a vendor to the vendor list

--- a/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
@@ -18,7 +18,6 @@ import wedlog.address.model.person.Vendor;
  * Adds a Vendor to Wedlog.
  */
 public class VendorAddCommand extends Command {
-    // implementation more or less copied from AddCommand
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD

--- a/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
@@ -1,25 +1,83 @@
 package wedlog.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static wedlog.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static wedlog.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static wedlog.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static wedlog.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static wedlog.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import wedlog.address.commons.util.ToStringBuilder;
+import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
 import wedlog.address.model.Model;
 import wedlog.address.model.person.Vendor;
 
 /**
- * Adds a Vendor to the address book.
+ * Adds a Vendor to Wedlog.
  */
 public class VendorAddCommand extends Command {
     // implementation more or less copied from AddCommand
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a vendor to the address book. ";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a vendor to the address book. "
+            + "Compulsory Parameters: "
+            + PREFIX_NAME + "NAME "
+            + "Optional Parameters: "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_ADDRESS + "ADDRESS "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "John Doe "
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_TAG + "florist";;
     public static final String MESSAGE_SUCCESS = "New vendor added: %1$s";
+    public static final String MESSAGE_DUPLICATE_VENDOR = "This vendor already exists in WedLog.";
 
+    private final Vendor toAdd;
+
+    /**
+     * Adds a Vendor to WedLog.
+     */
     public VendorAddCommand(Vendor vendor) {
-        // temporary empty constructor
+        requireNonNull(vendor);
+        this.toAdd = vendor;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("Command not created yet, wait for evolve for better testing");
+        requireNonNull(model);
+
+        if (model.hasVendor(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_VENDOR);
+        }
+
+        model.addVendor(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // checks that Object is a VendorAddCommand
+        if (!(other instanceof VendorAddCommand)) {
+            return false;
+        }
+
+        VendorAddCommand otherCommand = (VendorAddCommand) other;
+        return toAdd.equals(otherCommand.toAdd);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("toAddVendor", toAdd)
+                .toString();
     }
 }

--- a/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
@@ -10,6 +10,7 @@ import static wedlog.address.logic.parser.CliSyntax.PREFIX_TAG;
 import wedlog.address.commons.util.ToStringBuilder;
 import wedlog.address.logic.Messages;
 import wedlog.address.logic.commands.exceptions.CommandException;
+import wedlog.address.logic.parser.VendorCommandParser;
 import wedlog.address.model.Model;
 import wedlog.address.model.person.Vendor;
 
@@ -20,7 +21,8 @@ public class VendorAddCommand extends Command {
     // implementation more or less copied from AddCommand
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a vendor to the address book. "
+    public static final String MESSAGE_USAGE = VendorCommandParser.COMMAND_WORD + COMMAND_WORD
+            + ": Adds a vendor to the address book. "
             + "Compulsory Parameters: "
             + PREFIX_NAME + "NAME "
             + "Optional Parameters: "
@@ -28,7 +30,7 @@ public class VendorAddCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " "
+            + "Example: " + VendorCommandParser.COMMAND_WORD + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "

--- a/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
@@ -21,7 +21,7 @@ public class VendorAddCommand extends Command {
     // implementation more or less copied from AddCommand
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = VendorCommandParser.COMMAND_WORD + COMMAND_WORD
+    public static final String MESSAGE_USAGE = VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD
             + ": Adds a vendor to the address book. "
             + "Compulsory Parameters: "
             + PREFIX_NAME + "NAME "
@@ -30,7 +30,7 @@ public class VendorAddCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + VendorCommandParser.COMMAND_WORD + COMMAND_WORD + " "
+            + "Example: " + VendorCommandParser.COMMAND_WORD + " " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "

--- a/src/main/java/wedlog/address/logic/parser/VendorAddCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/VendorAddCommandParser.java
@@ -1,6 +1,8 @@
 package wedlog.address.logic.parser;
 
 import static wedlog.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static wedlog.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static wedlog.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -42,10 +44,13 @@ public class VendorAddCommandParser implements Parser<VendorAddCommand> {
         Phone phone = argMultimap.getValue(PREFIX_PHONE).isEmpty()
                 ? null
                 : ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = null;
-        Address address = null;
+        Email email = argMultimap.getValue(PREFIX_EMAIL).isEmpty()
+                ? null
+                : ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        Address address = argMultimap.getValue(PREFIX_EMAIL).isEmpty()
+                ? null
+                : ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-
 
 
         Vendor vendor = new Vendor(name, phone, email, address, tagList);

--- a/src/main/java/wedlog/address/logic/parser/VendorAddCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/VendorAddCommandParser.java
@@ -3,6 +3,7 @@ package wedlog.address.logic.parser;
 import static wedlog.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static wedlog.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static wedlog.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -13,12 +14,13 @@ import wedlog.address.model.person.Address;
 import wedlog.address.model.person.Email;
 import wedlog.address.model.person.Name;
 import wedlog.address.model.person.Phone;
+import wedlog.address.model.person.Vendor;
 import wedlog.address.model.tag.Tag;
 
 /**
  * Parses user input specifically for VendorAdd commands.
  */
-public class VendorAddCommandParser {
+public class VendorAddCommandParser implements Parser<VendorAddCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the VendorAddCommand
@@ -42,14 +44,12 @@ public class VendorAddCommandParser {
                 : ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = null;
         Address address = null;
-        Set<Tag> tagList = null;
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        // throw a ParseException as edits need to be made to Person/Guest/Vendor class first before this is valid
-        throw new ParseException("Vendor not created in VendorAddCommand due to un-evolved classes");
 
-        // once Person/Guest/Vendor classes are evolved, can edit & add this back in
-        // Person person = new Person(name, phone, email, address, tagList);
-        // return new VendorAddCommand(person);
+
+        Vendor vendor = new Vendor(name, phone, email, address, tagList);
+        return new VendorAddCommand(vendor);
     }
 
     /**

--- a/src/main/java/wedlog/address/logic/parser/VendorCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/VendorCommandParser.java
@@ -24,6 +24,7 @@ public class VendorCommandParser {
     /**
      * Used for initial separation of command word and args.
      */
+    public static final String COMMAND_WORD = "vendor";
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 

--- a/src/main/java/wedlog/address/model/person/Vendor.java
+++ b/src/main/java/wedlog/address/model/person/Vendor.java
@@ -8,7 +8,7 @@ import wedlog.address.model.tag.Tag;
 
 /**
  * Represents a Vendor in the address book.
- * Guarantees: details are present and not null, field values are validated, immutable.
+ * Guarantees: field values are validated, immutable.
  */
 public class Vendor extends Person {
 

--- a/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
@@ -40,6 +40,8 @@ public class CommandTestUtil {
     public static final String VALID_DIETARY_REQUIREMENTS_BOB = "no beef";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TAG_FLORIST = "florist";
+    public static final String VALID_TAG_PHOTOGRAPHER = "photographer";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -51,7 +53,8 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
-
+    public static final String TAG_DESC_FLORIST = " " + PREFIX_TAG + VALID_TAG_FLORIST;
+    public static final String TAG_DESC_PHOTOGRAPHER = " " + PREFIX_TAG + VALID_TAG_PHOTOGRAPHER;
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol

--- a/src/test/java/wedlog/address/logic/commands/VendorAddCommandIntegrationTest.java
+++ b/src/test/java/wedlog/address/logic/commands/VendorAddCommandIntegrationTest.java
@@ -34,15 +34,15 @@ public class VendorAddCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addVendor(validVendor);
 
-        assertCommandSuccess(new AddCommand(validVendor), model,
-                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),
+        assertCommandSuccess(new VendorAddCommand(validVendor), model,
+                String.format(VendorAddCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),
                 expectedModel);
     }
 
     @Test
     public void execute_duplicateVendor_throwsCommandException() {
         Vendor vendorInList = model.getAddressBook().getVendorList().get(0);
-        assertCommandFailure(new AddCommand(vendorInList), model,
+        assertCommandFailure(new VendorAddCommand(vendorInList), model,
                 VendorAddCommand.MESSAGE_DUPLICATE_VENDOR);
     }
 

--- a/src/test/java/wedlog/address/logic/commands/VendorAddCommandIntegrationTest.java
+++ b/src/test/java/wedlog/address/logic/commands/VendorAddCommandIntegrationTest.java
@@ -1,0 +1,49 @@
+package wedlog.address.logic.commands;
+
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static wedlog.address.testutil.TypicalVendors.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import wedlog.address.logic.Messages;
+import wedlog.address.model.Model;
+import wedlog.address.model.ModelManager;
+import wedlog.address.model.UserPrefs;
+import wedlog.address.model.person.Vendor;
+import wedlog.address.testutil.VendorBuilder;
+
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code VendorAddCommand}.
+ */
+public class VendorAddCommandIntegrationTest {
+
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_newVendor_success() {
+        Vendor validVendor = new VendorBuilder().build();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addVendor(validVendor);
+
+        assertCommandSuccess(new AddCommand(validVendor), model,
+                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),
+                expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateVendor_throwsCommandException() {
+        Vendor vendorInList = model.getAddressBook().getVendorList().get(0);
+        assertCommandFailure(new AddCommand(vendorInList), model,
+                VendorAddCommand.MESSAGE_DUPLICATE_VENDOR);
+    }
+
+}

--- a/src/test/java/wedlog/address/logic/commands/VendorAddCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/VendorAddCommandTest.java
@@ -1,0 +1,275 @@
+package wedlog.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static wedlog.address.testutil.Assert.assertThrows;
+import static wedlog.address.testutil.TypicalVendors.BOB;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import wedlog.address.commons.core.GuiSettings;
+import wedlog.address.logic.Messages;
+import wedlog.address.logic.commands.exceptions.CommandException;
+import wedlog.address.model.AddressBook;
+import wedlog.address.model.Model;
+import wedlog.address.model.ReadOnlyAddressBook;
+import wedlog.address.model.ReadOnlyUserPrefs;
+import wedlog.address.model.person.Guest;
+import wedlog.address.model.person.Person;
+import wedlog.address.model.person.Vendor;
+import wedlog.address.testutil.VendorBuilder;
+
+class VendorAddCommandTest {
+
+    @Test
+    public void constructor_nullVendor_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new VendorAddCommand(null));
+    }
+
+    @Test
+    public void execute_vendorAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingVendorAdded modelStub = new ModelStubAcceptingVendorAdded();
+        Vendor validVendor = new VendorBuilder().build();
+
+        CommandResult commandResult = new VendorAddCommand(validVendor).execute(modelStub);
+
+        assertEquals(String.format(VendorAddCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validVendor), modelStub.vendorsAdded);
+    }
+
+    @Test
+    public void execute_duplicateVendor_throwsCommandException() {
+        Vendor validVendor = new VendorBuilder().build();
+        VendorAddCommand vendorAddCommand = new VendorAddCommand(validVendor);
+        ModelStub modelStub = new ModelStubWithVendor(validVendor);
+
+        assertThrows(CommandException.class,
+                VendorAddCommand.MESSAGE_DUPLICATE_VENDOR, () -> vendorAddCommand.execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        Vendor alice = new VendorBuilder().withName("Alice").build();
+        Vendor bob = new VendorBuilder().withName("Bob").build();
+        VendorAddCommand addAliceCommand = new VendorAddCommand(alice);
+        VendorAddCommand addBobCommand = new VendorAddCommand(bob);
+
+        // same object -> returns true
+        assertTrue(addAliceCommand.equals(addAliceCommand));
+
+        // same values -> returns true
+        VendorAddCommand addAliceCommandCopy = new VendorAddCommand(alice);
+        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addAliceCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addAliceCommand.equals(null));
+
+        // different vendor -> returns false
+        assertFalse(addAliceCommand.equals(addBobCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        VendorAddCommand addCommand = new VendorAddCommand(BOB);
+        String expected = VendorAddCommand.class.getCanonicalName() + "{toAddVendor=" + BOB + "}";
+        assertEquals(expected, addCommand.toString());
+    }
+
+    /**
+     * A default model stub that have all the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        // add
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addGuest(Guest guest) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addVendor(Vendor vendor) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        // has
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasGuest(Guest guest) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasVendor(Vendor vendor) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        // delete
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteGuest(Guest guest) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteVendor(Vendor target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        // set
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuest(Guest target, Guest editedGuest) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setVendor(Vendor target, Vendor editedVendor) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Guest> getFilteredGuestList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredGuestList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Vendor> getFilteredVendorList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredVendorList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+    }
+
+    /**
+     * A Model stub that contains a single vendor.
+     */
+    private class ModelStubWithVendor extends ModelStub {
+        private final Vendor vendor;
+
+        ModelStubWithVendor(Vendor vendor) {
+            requireNonNull(vendor);
+            this.vendor = vendor;
+        }
+
+        @Override
+        public boolean hasVendor(Vendor vendor) {
+            requireNonNull(vendor);
+            return this.vendor.equals(vendor);
+        }
+    }
+
+    /**
+     * A Model stub that always accept the vendor being added.
+     */
+    private class ModelStubAcceptingVendorAdded extends ModelStub {
+        final ArrayList<Vendor> vendorsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasVendor(Vendor vendor) {
+            requireNonNull(vendor);
+            return vendorsAdded.stream().anyMatch(vendor::equals);
+        }
+
+        @Override
+        public void addVendor(Vendor vendor) {
+            requireNonNull(vendor);
+            vendorsAdded.add(vendor);
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            return new AddressBook();
+        }
+    }
+}

--- a/src/test/java/wedlog/address/logic/parser/VendorAddCommandParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/VendorAddCommandParserTest.java
@@ -1,10 +1,130 @@
 package wedlog.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static wedlog.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static wedlog.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static wedlog.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static wedlog.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static wedlog.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static wedlog.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static wedlog.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static wedlog.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static wedlog.address.testutil.TypicalVendors.AMY;
+
+import org.junit.jupiter.api.Test;
+
+import wedlog.address.logic.commands.VendorAddCommand;
+import wedlog.address.logic.parser.exceptions.ParseException;
+import wedlog.address.model.person.Name;
+import wedlog.address.model.person.Phone;
+import wedlog.address.model.person.Vendor;
+import wedlog.address.testutil.VendorBuilder;
+
 public class VendorAddCommandParserTest {
     private VendorAddCommandParser parser = new VendorAddCommandParser();
+    @Test
+    public void parse_allFieldsPresent_success() throws ParseException {
+        VendorAddCommand vendorAddCommand = parser.parse(NAME_DESC_AMY + PHONE_DESC_AMY);
+        assertEquals(vendorAddCommand, new VendorAddCommand(AMY));
+    }
 
-    // parse all field present test success
-    // parse optional fields missing test success
-    // parse compulsory fields missing test fail
-    // parse invalid values test fail
+    @Test
+    public void parse_onlyNamePresent_success() throws ParseException {
+        Vendor expectedVendor = new VendorBuilder(VALID_NAME_AMY).build();
+        VendorAddCommand vendorAddCommand = parser.parse(NAME_DESC_AMY);
+        assertEquals(new VendorAddCommand(expectedVendor), vendorAddCommand);
+    }
+
+    @Test
+    public void parse_repeatedNameValue_failure() throws ParseException {
+        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+
+        assertThrows(ParseException.class, () -> parser.parse(NAME_DESC_AMY + validExpectedPersonString));
+    }
+
+    @Test
+    public void parse_invalidValues_failure() throws ParseException {
+        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB
+                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+
+        // invalid value followed by valid value
+
+        // invalid name
+        assertThrows(ParseException.class, () -> parser.parse(INVALID_NAME_DESC + validExpectedPersonString));
+
+        // invalid email
+        assertThrows(ParseException.class, () -> parser.parse(INVALID_EMAIL_DESC + validExpectedPersonString));
+
+
+        // valid value followed by invalid value
+
+        // invalid name
+        assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_NAME_DESC));
+
+        // invalid email
+        assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_EMAIL_DESC));
+
+        // invalid phone
+        assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_PHONE_DESC));
+
+        // invalid address
+        assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_ADDRESS_DESC));
+
+    }
+
+    @Test
+    public void parse_missingTags_success() {
+        // zero tags
+        Vendor expectedVendor = new VendorBuilder(AMY).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY,
+                new VendorAddCommand(expectedVendor));
+    }
+
+    @Test
+    public void parse_missingPhone_success() {
+        Vendor expectedVendor = new VendorBuilder("Bob Choo").build();
+        assertParseSuccess(parser, NAME_DESC_BOB, new VendorAddCommand(expectedVendor));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, VendorAddCommand.MESSAGE_USAGE);
+
+        // missing name prefix
+        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid phone
+        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                        + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, VendorAddCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/wedlog/address/logic/parser/VendorCommandParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/VendorCommandParserTest.java
@@ -16,8 +16,6 @@ import wedlog.address.logic.commands.VendorViewCommand;
 import wedlog.address.logic.parser.exceptions.ParseException;
 
 public class VendorCommandParserTest {
-    private static final String VENDOR_ADD_PARSE_EXCEPTION_MSG =
-            "Vendor not created in VendorAddCommand due to un-evolved classes";
     private VendorCommandParser parser = new VendorCommandParser();
 
     // test vendor add

--- a/src/test/java/wedlog/address/logic/parser/VendorCommandParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/VendorCommandParserTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import wedlog.address.logic.commands.Command;
 import wedlog.address.logic.commands.HelpCommand;
+import wedlog.address.logic.commands.VendorAddCommand;
 import wedlog.address.logic.commands.VendorDeleteCommand;
 import wedlog.address.logic.commands.VendorListCommand;
 import wedlog.address.logic.commands.VendorViewCommand;
@@ -23,12 +24,9 @@ public class VendorCommandParserTest {
     @Test
     public void parseCommand_vendorAdd() throws Exception {
         String input = "add n/vendor p/102391";
-        // expected type, expected string, executable
-        assertThrows(ParseException.class, VENDOR_ADD_PARSE_EXCEPTION_MSG, () -> parser.parseCommand(input));
 
-        // test for when Guest/Vendor/Person is evolved
-        // Command command = parser.parseCommand(input);
-        // assertTrue(command instanceof VendorAddCommand);
+        Command command = parser.parseCommand(input);
+        assertTrue(command instanceof VendorAddCommand);
     }
 
     @Test

--- a/src/test/java/wedlog/address/testutil/TypicalVendors.java
+++ b/src/test/java/wedlog/address/testutil/TypicalVendors.java
@@ -1,15 +1,12 @@
 package wedlog.address.testutil;
 
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_FLORIST;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,10 +46,9 @@ public class TypicalVendors {
             .withEmail("muellerirene@example.com").withAddress("chicago ave").build();
 
     // Manually added - Vendor's details found in {@code CommandTestUtil}
-    public static final Vendor AMY = new VendorBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
+    public static final Vendor AMY = new VendorBuilder(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).build();
     public static final Vendor BOB = new VendorBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FLORIST)
             .build();
 
     private TypicalVendors() {} // prevents instantiation

--- a/src/test/java/wedlog/address/testutil/VendorBuilder.java
+++ b/src/test/java/wedlog/address/testutil/VendorBuilder.java
@@ -39,6 +39,17 @@ public class VendorBuilder {
     }
 
     /**
+     * Creates a {@code VendorBuilder} with only the given name.
+     */
+    public VendorBuilder(String name) {
+        this.name = new Name(name);
+        phone = null;
+        email = null;
+        address = null;
+        tags = new HashSet<>();
+    }
+
+    /**
      * Initializes the VendorBuilder with the data of {@code vendorToCopy}.
      */
     public VendorBuilder(Vendor vendorToCopy) {


### PR DESCRIPTION
Resolves #59.

Currently, the VendorAddCommand throws an exception when it is executed.

Let's implement the logic of executing a VendorAddCommand.

This will allow users to add vendors to WedLog