### PR TITLE
Fix: loading data from local storage

### DIFF
--- a/src/main/java/wedlog/address/model/person/Guest.java
+++ b/src/main/java/wedlog/address/model/person/Guest.java
@@ -26,8 +26,8 @@ public class Guest extends Person {
         super(name, phone, email, address, tags);
         requireAllNonNull(rsvpStatus);
         this.rsvpStatus = rsvpStatus;
-        this.dietaryRequirements = Objects.requireNonNullElseGet(dietaryRequirements,
-                () -> new DietaryRequirements(null));
+        this.dietaryRequirements =
+                Objects.requireNonNullElseGet(dietaryRequirements, () -> new DietaryRequirements(null));
     }
 
     public RsvpStatus getRsvpStatus() {

--- a/src/main/java/wedlog/address/model/person/Guest.java
+++ b/src/main/java/wedlog/address/model/person/Guest.java
@@ -24,7 +24,7 @@ public class Guest extends Person {
     public Guest(Name name, Phone phone, Email email, Address address, RsvpStatus rsvpStatus,
                  DietaryRequirements dietaryRequirements, Set<Tag> tags) {
         super(name, phone, email, address, tags);
-        requireAllNonNull(rsvpStatus, dietaryRequirements);
+        requireAllNonNull(rsvpStatus);
         this.rsvpStatus = rsvpStatus;
         this.dietaryRequirements = dietaryRequirements;
     }

--- a/src/main/java/wedlog/address/model/person/Guest.java
+++ b/src/main/java/wedlog/address/model/person/Guest.java
@@ -26,7 +26,8 @@ public class Guest extends Person {
         super(name, phone, email, address, tags);
         requireAllNonNull(rsvpStatus);
         this.rsvpStatus = rsvpStatus;
-        this.dietaryRequirements = dietaryRequirements;
+        this.dietaryRequirements = Objects.requireNonNullElseGet(dietaryRequirements,
+                () -> new DietaryRequirements(null));
     }
 
     public RsvpStatus getRsvpStatus() {

--- a/src/main/java/wedlog/address/storage/JsonAdaptedGuest.java
+++ b/src/main/java/wedlog/address/storage/JsonAdaptedGuest.java
@@ -111,8 +111,7 @@ class JsonAdaptedGuest extends JsonAdaptedPerson {
 
         final DietaryRequirements modelDietaryRequirements;
         if (dietaryRequirements == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    DietaryRequirements.class.getSimpleName()));
+            modelDietaryRequirements = null;
         } else {
             // Dietary Requirements are always valid
             modelDietaryRequirements = new DietaryRequirements(dietaryRequirements);

--- a/src/test/java/wedlog/address/model/person/GuestTest.java
+++ b/src/test/java/wedlog/address/model/person/GuestTest.java
@@ -61,13 +61,13 @@ public class GuestTest {
         assertDoesNotThrow(() -> new Guest(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
                 VALID_RSVP_STATUS, VALID_DIETARY_REQUIREMENTS, VALID_TAGS));
 
+        // Dietary Requirements Null
+        assertDoesNotThrow(() -> new Guest(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS, VALID_RSVP_STATUS, null, VALID_TAGS));
+
         // Rsvp Status Null
         assertThrows(NullPointerException.class, () -> new Guest(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS, null, VALID_DIETARY_REQUIREMENTS, VALID_TAGS));
-
-        // Dietary Requirements Null
-        assertThrows(NullPointerException.class, () -> new Guest(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, VALID_RSVP_STATUS, null, VALID_TAGS));
 
         // Tags Null
         assertThrows(NullPointerException.class, () -> new Guest(VALID_NAME, VALID_PHONE, VALID_EMAIL,

--- a/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
+++ b/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
@@ -39,6 +39,10 @@ public class JsonAdaptedGuestTest {
     private static final String VALID_NO_RSVP_STATUS = GREG.getRsvpStatus().toString();
     private static final String VALID_UNKNOWN_RSVP_STATUS = GABRIEL.getRsvpStatus().toString();
     private static final String VALID_DIETARY_REQUIREMENTS = GINA.getDietaryRequirements().toString();
+    private static final String VALID_NONE_DIETARY_REQUIREMENTS = GREG.getDietaryRequirements().toString();
+    private static final String VALID_NULL_DIETARY_REQUIREMENTS = GABRIEL.getDietaryRequirements().toString();
+    private static final String VALID_PRESENT_DIETARY_REQUIREMENTS = GINA.getDietaryRequirements().toString();
+
     private static final List<JsonAdaptedTag> VALID_TAGS = GINA.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -153,6 +157,28 @@ public class JsonAdaptedGuestTest {
         guest = new JsonAdaptedGuest(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 VALID_UNKNOWN_RSVP_STATUS, VALID_DIETARY_REQUIREMENTS, VALID_TAGS);
         expectedGuest = new GuestBuilder(GINA).withRsvpStatus(VALID_UNKNOWN_RSVP_STATUS).build();
+        assertEquals(expectedGuest, guest.toModelType());
+    }
+
+    @Test
+    public void toModelType_validDietaryRequirements_returnsGuest() throws Exception {
+        // none dietary requirements status
+        JsonAdaptedGuest guest =
+                new JsonAdaptedGuest(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_RSVP_STATUS, VALID_NONE_DIETARY_REQUIREMENTS, VALID_TAGS);
+        Guest expectedGuest = new GuestBuilder(GINA).withDietaryRequirements(VALID_NONE_DIETARY_REQUIREMENTS).build();
+        assertEquals(expectedGuest, guest.toModelType());
+
+        // null dietary requirements status
+        guest = new JsonAdaptedGuest(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_RSVP_STATUS, VALID_NULL_DIETARY_REQUIREMENTS, VALID_TAGS);
+        expectedGuest = new GuestBuilder(GINA).withDietaryRequirements(VALID_NULL_DIETARY_REQUIREMENTS).build();
+        assertEquals(expectedGuest, guest.toModelType());
+
+        // present dietary requirements status
+        guest = new JsonAdaptedGuest(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_RSVP_STATUS, VALID_PRESENT_DIETARY_REQUIREMENTS, VALID_TAGS);
+        expectedGuest = new GuestBuilder(GINA).withDietaryRequirements(VALID_PRESENT_DIETARY_REQUIREMENTS).build();
         assertEquals(expectedGuest, guest.toModelType());
     }
 

--- a/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
+++ b/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
@@ -158,16 +158,6 @@ public class JsonAdaptedGuestTest {
     }
 
     @Test
-    public void toModelType_nullDietaryRequirements_throwsIllegalValueException() throws Exception {
-        JsonAdaptedGuest guest =
-                new JsonAdaptedGuest(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_RSVP_STATUS,
-                        null, VALID_TAGS);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                DietaryRequirements.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, guest::toModelType);
-    }
-
-    @Test
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));

--- a/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
+++ b/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import wedlog.address.commons.exceptions.IllegalValueException;
 import wedlog.address.model.person.Address;
-import wedlog.address.model.person.DietaryRequirements;
 import wedlog.address.model.person.Email;
 import wedlog.address.model.person.Guest;
 import wedlog.address.model.person.Name;

--- a/src/test/java/wedlog/address/testutil/TypicalGuests.java
+++ b/src/test/java/wedlog/address/testutil/TypicalGuests.java
@@ -38,7 +38,7 @@ public class TypicalGuests {
             .withTags("owesMoney", "friends").build();
     public static final Guest GABRIEL = new GuestBuilder().withName("Gabriel Kurz").withPhone("95352563")
             .withEmail("gabkurz@example.com").withAddress("wall street")
-            .withRsvpStatus("unknown").withDietaryRequirements("vegetarian")
+            .withRsvpStatus("unknown").withDietaryRequirements(null)
             .build();
     public static final Guest GEORGE = new GuestBuilder().withName("George Tan").withPhone("87652533")
             .withEmail("georgemeier@example.com").withAddress("10th street")

--- a/src/test/java/wedlog/address/testutil/TypicalGuests.java
+++ b/src/test/java/wedlog/address/testutil/TypicalGuests.java
@@ -38,7 +38,7 @@ public class TypicalGuests {
             .withTags("owesMoney", "friends").build();
     public static final Guest GABRIEL = new GuestBuilder().withName("Gabriel Kurz").withPhone("95352563")
             .withEmail("gabkurz@example.com").withAddress("wall street")
-            .withRsvpStatus("unknown").withDietaryRequirements(null)
+            .withRsvpStatus("unknown").withNullDietaryRequirements()
             .build();
     public static final Guest GEORGE = new GuestBuilder().withName("George Tan").withPhone("87652533")
             .withEmail("georgemeier@example.com").withAddress("10th street")


### PR DESCRIPTION
Currently, dietary requirements can be stored as null in `addressbook.json`. `JsonAdaptedGuest` will catch this can throw an exception, causing data to be unable to be loaded.

Let's prevent `JsonAdaptedGuest` from throwing an exception upon a null dietary requirement, and allow `Guest` to be constructed with a null dietary requirement.