### PR TITLE
Add `undo` and `redo` commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -321,7 +321,7 @@ Expected behaviour upon failure:
 
 --------------------------------------------------------------------------------------------------------------------
 ### Redoing last action: `redo`
-Redoes the last action that was undone
+Reverses the last action that was undone.
 
 ```text
 redo

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -303,6 +303,40 @@ Expected behaviour upon failure:
 - No input number: Displays error message “Please input an index”
 
 --------------------------------------------------------------------------------------------------------------------
+### Undoing last action: `undo`
+Undoes the last action.
+
+```text
+undo
+```
+
+Examples
+- `vendor delete 2` followed by `undo` deletes, then restores the 2nd vendor in WedLog.
+
+Expected behaviour upon success:
+- Restores WedLog to its previous state
+
+Expected behaviour upon failure:
+- No states to undo: Displays error message “There is no change to undo!”
+
+--------------------------------------------------------------------------------------------------------------------
+### Redoing last action: `redo`
+Redoes the last action that was undone
+
+```text
+redo
+```
+
+Examples
+- `vendor delete 2`, followed by `undo`, followed by `redo` deletes, then restores, then re-deletes the 2nd vendor in WedLog.
+
+Expected behaviour upon success:
+- Restores WedLog to its previous state before the last undo
+
+Expected behaviour upon failure:
+- No states to redo: Displays error message “There is no change to redo!”
+
+--------------------------------------------------------------------------------------------------------------------
 ### Exiting the program: `exit`
 Exits the program.
 
@@ -337,7 +371,9 @@ exit
 | **View specific guest**  | `guest view INDEX`                                                                                            | `guest view 1`                                                                                |
 | **View all vendors**     | `vendor list`                                                                                                 |                                                                                               |
 | **View specific vendor** | `vendor view INDEX`                                                                                           | `vendor view 1`                                                                               |
-| **Exit program**         | `exit`                                                                                                        |
+| **Undo last action**     | `undo`                                                                                                        |                                                                                               |
+| **Redo last action**     | `redo`                                                                                                        |                                                                                               |
+| **Exit program**         | `exit`                                                                                                        |                                                                                               |
 
 --------------------------------------------------------------------------------------------------------------------
 ## Appendix A: Miscellaneous error messages

--- a/docs/diagrams/DeleteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteSequenceDiagram.puml
@@ -66,7 +66,7 @@ deactivate AddressBookParser
 LogicManager -> GuestDeleteCommand : execute()
 activate GuestDeleteCommand
 
-GuestDeleteCommand -> Model : deletePerson(1)
+GuestDeleteCommand -> Model : deleteGuest(1)
 activate Model
 
 Model --> GuestDeleteCommand

--- a/docs/diagrams/ModelClassDiagram.puml
+++ b/docs/diagrams/ModelClassDiagram.puml
@@ -9,6 +9,7 @@ Class "<<interface>>\nReadOnlyAddressBook" as ReadOnlyAddressBook
 Class "<<interface>>\nReadOnlyUserPrefs" as ReadOnlyUserPrefs
 Class "<<interface>>\nModel" as Model
 Class AddressBook
+Class VersionedAddressBook
 Class ModelManager
 Class UserPrefs
 
@@ -36,12 +37,13 @@ AddressBook .up.|> ReadOnlyAddressBook
 ModelManager .up.|> Model
 Model .right.> ReadOnlyUserPrefs
 Model .left.> ReadOnlyAddressBook
-ModelManager -left-> "1" AddressBook
+ModelManager -left-> "1" VersionedAddressBook
+VersionedAddressBook -left-|> AddressBook
 ModelManager -right-> "1" UserPrefs
 UserPrefs .up.|> ReadOnlyUserPrefs
 
-AddressBook *--> "1" UniqueGuestList
-AddressBook *--> "1" UniqueVendorList
+VersionedAddressBook *--> "1" UniqueGuestList
+VersionedAddressBook *--> "1" UniqueVendorList
 
 UniqueGuestList --> "*" Guest
 UniqueVendorList --> "*" Vendor

--- a/src/main/java/wedlog/address/logic/commands/ClearCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/ClearCommand.java
@@ -18,6 +18,7 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
+        model.commitAddressBook();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/wedlog/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/DeleteCommand.java
@@ -42,6 +42,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
 

--- a/src/main/java/wedlog/address/logic/commands/EditCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/EditCommand.java
@@ -85,6 +85,7 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/wedlog/address/logic/commands/GuestAddCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestAddCommand.java
@@ -61,6 +61,7 @@ public class GuestAddCommand extends Command {
         }
 
         model.addGuest(toAdd);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
@@ -42,6 +42,7 @@ public class GuestDeleteCommand extends Command {
 
         Guest guestToDelete = lastShownGuestList.get(targetIndex.getZeroBased());
         model.deleteGuest(guestToDelete);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_DELETE_GUEST_SUCCESS, Messages.format(guestToDelete)));
     }
 

--- a/src/main/java/wedlog/address/logic/commands/RedoCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/RedoCommand.java
@@ -1,0 +1,40 @@
+package wedlog.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static wedlog.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import wedlog.address.logic.commands.exceptions.CommandException;
+import wedlog.address.model.Model;
+
+//@@author samuelim01-reused
+// Reused from Address Book(Level 4) with minor modifications.
+
+/**
+ * Restores the {@code Model}'s address book to its previous state before undo.
+ */
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the most recent change before undo to WedLog. ";
+
+    public static final String MESSAGE_SUCCESS = "Redo successful.";
+    public static final String MESSAGE_FAILURE = "There is no change to redo!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (!model.canRedoAddressBook()) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+
+        model.redoAddressBook();
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredGuestList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredVendorList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+}
+
+//@author

--- a/src/main/java/wedlog/address/logic/commands/RedoCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/RedoCommand.java
@@ -16,7 +16,7 @@ public class RedoCommand extends Command {
 
     public static final String COMMAND_WORD = "redo";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the most recent change before undo to WedLog. ";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Reverses the most recent undo command to WedLog. ";
 
     public static final String MESSAGE_SUCCESS = "Redo successful.";
     public static final String MESSAGE_FAILURE = "There is no change to redo!";

--- a/src/main/java/wedlog/address/logic/commands/UndoCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/UndoCommand.java
@@ -1,0 +1,40 @@
+package wedlog.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static wedlog.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import wedlog.address.logic.commands.exceptions.CommandException;
+import wedlog.address.model.Model;
+
+//@@author samuelim01-reused
+// Reused from Address Book(Level 4) with minor modifications.
+
+/**
+ * Restores the {@code Model}'s address book to its previous state.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the most recent change to WedLog. ";
+
+    public static final String MESSAGE_SUCCESS = "Undo successful.";
+    public static final String MESSAGE_FAILURE = "There is no change to undo!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (!model.canUndoAddressBook()) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+
+        model.undoAddressBook();
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredGuestList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredVendorList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+}
+
+//@@author

--- a/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorAddCommand.java
@@ -57,6 +57,7 @@ public class VendorAddCommand extends Command {
         }
 
         model.addVendor(toAdd);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
@@ -42,6 +42,7 @@ public class VendorDeleteCommand extends Command {
 
         Vendor vendorToDelete = lastShownVendorList.get(targetIndex.getZeroBased());
         model.deleteVendor(vendorToDelete);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_DELETE_VENDOR_SUCCESS, Messages.format(vendorToDelete)));
     }
 

--- a/src/main/java/wedlog/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/wedlog/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,8 @@ import wedlog.address.logic.commands.ExitCommand;
 import wedlog.address.logic.commands.FindCommand;
 import wedlog.address.logic.commands.HelpCommand;
 import wedlog.address.logic.commands.ListCommand;
+import wedlog.address.logic.commands.RedoCommand;
+import wedlog.address.logic.commands.UndoCommand;
 import wedlog.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -74,6 +76,13 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
+
         // change it from here to split between vendor
         case "vendor": // there shouldn't be a need to create an entire new vendor/guest command class
             return new VendorCommandParser().parseCommand(arguments);

--- a/src/main/java/wedlog/address/model/Model.java
+++ b/src/main/java/wedlog/address/model/Model.java
@@ -55,6 +55,31 @@ public interface Model {
     ReadOnlyAddressBook getAddressBook();
 
     /**
+     * Saves the current address book state.
+     */
+    void commitAddressBook();
+
+    /**
+     * Restores the address book to its previous state.
+     */
+    void undoAddressBook();
+
+    /**
+     * Restores the address book to its previously state before undo.
+     */
+    void redoAddressBook();
+
+    /**
+     * Returns true if the address book has previous states to restore.
+     */
+    boolean canUndoAddressBook();
+
+    /**
+     * Returns true if the address book has undone states to restore.
+     */
+    boolean canRedoAddressBook();
+
+    /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     boolean hasPerson(Person person);

--- a/src/main/java/wedlog/address/model/ModelManager.java
+++ b/src/main/java/wedlog/address/model/ModelManager.java
@@ -21,7 +21,7 @@ import wedlog.address.model.person.Vendor;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final AddressBook addressBook;
+    private final VersionedAddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Guest> filteredGuests;
@@ -35,7 +35,7 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
-        this.addressBook = new AddressBook(addressBook);
+        this.addressBook = new VersionedAddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredGuests = new FilteredList<>(this.addressBook.getGuestList());
@@ -91,6 +91,31 @@ public class ModelManager implements Model {
     @Override
     public ReadOnlyAddressBook getAddressBook() {
         return addressBook;
+    }
+
+    @Override
+    public void commitAddressBook() {
+        addressBook.commit();
+    }
+
+    @Override
+    public void undoAddressBook() {
+        addressBook.undo();
+    }
+
+    @Override
+    public void redoAddressBook() {
+        addressBook.redo();
+    }
+
+    @Override
+    public boolean canUndoAddressBook() {
+        return addressBook.canUndo();
+    }
+
+    @Override
+    public boolean canRedoAddressBook() {
+        return addressBook.canRedo();
     }
 
     @Override

--- a/src/main/java/wedlog/address/model/VersionedAddressBook.java
+++ b/src/main/java/wedlog/address/model/VersionedAddressBook.java
@@ -1,0 +1,108 @@
+package wedlog.address.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+//@@author samuelim01-reused
+// Reused from Address Book(Level 4) with minor modifications.
+
+/**
+ * {@code AddressBook} that keeps track of its own history
+ */
+public class VersionedAddressBook extends AddressBook {
+
+    private final List<ReadOnlyAddressBook> addressBookStateList;
+    private int currentStatePointer;
+
+
+    /**
+     * Creates an AddressBook using the persons in {@code initialState}
+     * @param initialState
+     */
+    public VersionedAddressBook(ReadOnlyAddressBook initialState) {
+        super(initialState);
+
+        addressBookStateList = new ArrayList<>();
+        addressBookStateList.add(new AddressBook(initialState));
+        currentStatePointer = 0;
+    }
+
+    /**
+     * Saves a copy of the current {@code AddressBook} state.
+     */
+    public void commit() {
+        removeStatesAfterCurrentStatePointer();
+        addressBookStateList.add(new AddressBook(this));
+        currentStatePointer++;
+    }
+
+    private void removeStatesAfterCurrentStatePointer() {
+        addressBookStateList.subList(currentStatePointer + 1, addressBookStateList.size()).clear();
+    }
+
+    /**
+     * Restores the address book to its previous state.
+     */
+    public void undo() {
+        if (!canUndo()) {
+            throw new NoUndoableStateException();
+        }
+        currentStatePointer--;
+        resetData(addressBookStateList.get(currentStatePointer));
+    }
+
+    /**
+     * Restores the address book to its previous state before undo.
+     */
+    public void redo() {
+        if (!canRedo()) {
+            throw new NoRedoableStateException();
+        }
+        currentStatePointer++;
+        resetData(addressBookStateList.get(currentStatePointer));
+    }
+
+    public boolean canUndo() {
+        return currentStatePointer > 0;
+    }
+
+    public boolean canRedo() {
+        return currentStatePointer < addressBookStateList.size() - 1;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof VersionedAddressBook)) {
+            return false;
+        }
+
+        VersionedAddressBook otherAddressBook = (VersionedAddressBook) other;
+        return super.equals(otherAddressBook)
+                && addressBookStateList.equals(otherAddressBook.addressBookStateList)
+                && currentStatePointer == otherAddressBook.currentStatePointer;
+    }
+
+    /**
+     * Thrown when trying to {@code undo} with no undoable state.
+     */
+    public static class NoUndoableStateException extends RuntimeException {
+        private NoUndoableStateException() {
+            super("Current state pointer at start of list, unable to undo.");
+        }
+    }
+
+    /**
+     * Thrown when trying to {@code redo} with no redoable state.
+     */
+    public static class NoRedoableStateException extends RuntimeException {
+        private NoRedoableStateException() {
+            super("Current state pointer at end of list, unable to redo.");
+        }
+    }
+}
+//@@author

--- a/src/test/java/wedlog/address/logic/LogicManagerTest.java
+++ b/src/test/java/wedlog/address/logic/LogicManagerTest.java
@@ -187,6 +187,7 @@ public class LogicManagerTest {
         Guest expectedGuest = new GuestBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addGuest(expectedGuest);
+        expectedModel.commitAddressBook();
         assertCommandFailure(guestAddCommand, CommandException.class, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/wedlog/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/ClearCommandTest.java
@@ -16,6 +16,7 @@ public class ClearCommandTest {
     public void execute_emptyAddressBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
@@ -25,6 +26,7 @@ public class ClearCommandTest {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
@@ -169,4 +169,16 @@ public class CommandTestUtil {
 
         assertEquals(1, model.getFilteredVendorList().size());
     }
+
+    /**
+     * Inspired by AddressBook Level 4
+     * Deletes {@code model}'s first guest from the {@code model}'s address book.
+     */
+    public static void deleteFirstGuest(Model model) {
+        assertTrue(model.getFilteredGuestList().size() > 0);
+
+        Guest firstGuest = model.getFilteredGuestList().get(0);
+        model.deleteGuest(firstGuest);
+        model.commitAddressBook();
+    }
 }

--- a/src/test/java/wedlog/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/DeleteCommandTest.java
@@ -37,6 +37,7 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
@@ -61,6 +62,7 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
+        expectedModel.commitAddressBook();
         showNoPerson(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/wedlog/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/EditCommandTest.java
@@ -45,6 +45,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -66,6 +67,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -78,6 +80,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -95,6 +98,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/wedlog/address/logic/commands/GuestAddCommandIntegrationTest.java
+++ b/src/test/java/wedlog/address/logic/commands/GuestAddCommandIntegrationTest.java
@@ -34,6 +34,7 @@ public class GuestAddCommandIntegrationTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addGuest(validGuest);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(new GuestAddCommand(validGuest), model,
                 String.format(GuestAddCommand.MESSAGE_SUCCESS, Messages.format(validGuest)),
@@ -46,6 +47,7 @@ public class GuestAddCommandIntegrationTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addGuest(validGuest);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(new GuestAddCommand(validGuest), model,
                 String.format(GuestAddCommand.MESSAGE_SUCCESS, Messages.format(validGuest)),

--- a/src/test/java/wedlog/address/logic/commands/GuestAddCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/GuestAddCommandTest.java
@@ -144,7 +144,7 @@ class GuestAddCommandTest {
 
         @Override
         public void commitAddressBook() {
-            throw new AssertionError("This method should not be called.");
+            // called by GuestAddCommand#execute()
         }
 
         @Override

--- a/src/test/java/wedlog/address/logic/commands/GuestAddCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/GuestAddCommandTest.java
@@ -143,6 +143,31 @@ class GuestAddCommandTest {
         }
 
         @Override
+        public void commitAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void undoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void redoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canUndoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canRedoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/wedlog/address/logic/commands/GuestDeleteCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/GuestDeleteCommandTest.java
@@ -37,6 +37,7 @@ public class GuestDeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteGuest(guestToDelete);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(guestDeleteCommand, model, expectedMessage, expectedModel);
     }
@@ -61,6 +62,7 @@ public class GuestDeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteGuest(guestToDelete);
+        expectedModel.commitAddressBook();
         showNoPerson(expectedModel);
 
         assertCommandSuccess(guestDeleteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/wedlog/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/RedoCommandTest.java
@@ -1,0 +1,68 @@
+package wedlog.address.logic.commands;
+
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static wedlog.address.logic.commands.CommandTestUtil.deleteFirstGuest;
+import static wedlog.address.logic.commands.CommandTestUtil.showGuestAtIndex;
+import static wedlog.address.testutil.TypicalGuests.getTypicalAddressBook;
+import static wedlog.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import wedlog.address.model.Model;
+import wedlog.address.model.ModelManager;
+import wedlog.address.model.UserPrefs;
+
+//@@author samuelim01-reused
+// Reused from Address Book(Level 4) with minor modifications.
+
+class RedoCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    void execute_multipleRedoableStates_commandSuccess() {
+        deleteFirstGuest(expectedModel);
+        deleteFirstGuest(expectedModel);
+        expectedModel.undoAddressBook();
+        expectedModel.undoAddressBook();
+        expectedModel.redoAddressBook();
+
+        deleteFirstGuest(model);
+        deleteFirstGuest(model);
+        model.undoAddressBook();
+        model.undoAddressBook();
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    void execute_singleRedoableState_commandSuccess() {
+        deleteFirstGuest(expectedModel);
+        expectedModel.undoAddressBook();
+        expectedModel.redoAddressBook();
+
+        deleteFirstGuest(model);
+        model.undoAddressBook();
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    void execute_noRedoableStates_commandSuccess() {
+        assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_FAILURE);
+    }
+
+    @Test
+    void execute_listIsFiltered_showsEverything() {
+        deleteFirstGuest(expectedModel);
+        expectedModel.undoAddressBook();
+        expectedModel.redoAddressBook();
+
+        deleteFirstGuest(model);
+        model.undoAddressBook();
+        showGuestAtIndex(model, INDEX_FIRST_PERSON);
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}
+
+//@author

--- a/src/test/java/wedlog/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/UndoCommandTest.java
@@ -1,0 +1,61 @@
+package wedlog.address.logic.commands;
+
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static wedlog.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static wedlog.address.logic.commands.CommandTestUtil.deleteFirstGuest;
+import static wedlog.address.logic.commands.CommandTestUtil.showGuestAtIndex;
+import static wedlog.address.testutil.TypicalGuests.getTypicalAddressBook;
+import static wedlog.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import wedlog.address.model.Model;
+import wedlog.address.model.ModelManager;
+import wedlog.address.model.UserPrefs;
+
+//@@author samuelim01-reused
+// Reused from Address Book(Level 4) with minor modifications.
+
+class UndoCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    void execute_multipleUndoableStates_commandSuccess() {
+        deleteFirstGuest(expectedModel);
+        deleteFirstGuest(expectedModel);
+        expectedModel.undoAddressBook();
+
+        deleteFirstGuest(model);
+        deleteFirstGuest(model);
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    void execute_singleUndoableState_commandSuccess() {
+        deleteFirstGuest(expectedModel);
+        expectedModel.undoAddressBook();
+
+        deleteFirstGuest(model);
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    void execute_noUndoableStates_commandSuccess() {
+        assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_FAILURE);
+    }
+
+    @Test
+    void execute_listIsFiltered_showsEverything() {
+        deleteFirstGuest(expectedModel);
+        expectedModel.undoAddressBook();
+
+        deleteFirstGuest(model);
+        showGuestAtIndex(model, INDEX_FIRST_PERSON);
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+}
+
+//@author

--- a/src/test/java/wedlog/address/logic/commands/VendorAddCommandIntegrationTest.java
+++ b/src/test/java/wedlog/address/logic/commands/VendorAddCommandIntegrationTest.java
@@ -35,6 +35,7 @@ public class VendorAddCommandIntegrationTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addVendor(validVendor);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(new VendorAddCommand(validVendor), model,
                 String.format(VendorAddCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),
@@ -47,6 +48,7 @@ public class VendorAddCommandIntegrationTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addVendor(validVendor);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(new VendorAddCommand(validVendor), model,
                 String.format(VendorAddCommand.MESSAGE_SUCCESS, Messages.format(validVendor)),

--- a/src/test/java/wedlog/address/logic/commands/VendorAddCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/VendorAddCommandTest.java
@@ -132,6 +132,31 @@ class VendorAddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        @Override
+        public void commitAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void undoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void redoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canUndoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canRedoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
         // add
         @Override
         public void addPerson(Person person) {

--- a/src/test/java/wedlog/address/logic/commands/VendorAddCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/VendorAddCommandTest.java
@@ -134,7 +134,7 @@ class VendorAddCommandTest {
 
         @Override
         public void commitAddressBook() {
-            throw new AssertionError("This method should not be called.");
+            // called by VendorAddCommand#execute()
         }
 
         @Override

--- a/src/test/java/wedlog/address/logic/commands/VendorDeleteCommandTest.java
+++ b/src/test/java/wedlog/address/logic/commands/VendorDeleteCommandTest.java
@@ -37,6 +37,7 @@ public class VendorDeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteVendor(vendorToDelete);
+        expectedModel.commitAddressBook();
 
         assertCommandSuccess(vendorDeleteCommand, model, expectedMessage, expectedModel);
     }
@@ -61,6 +62,7 @@ public class VendorDeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteVendor(vendorToDelete);
+        expectedModel.commitAddressBook();
         showNoPerson(expectedModel);
 
         assertCommandSuccess(vendorDeleteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/wedlog/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/AddressBookParserTest.java
@@ -22,6 +22,8 @@ import wedlog.address.logic.commands.ExitCommand;
 import wedlog.address.logic.commands.FindCommand;
 import wedlog.address.logic.commands.HelpCommand;
 import wedlog.address.logic.commands.ListCommand;
+import wedlog.address.logic.commands.RedoCommand;
+import wedlog.address.logic.commands.UndoCommand;
 import wedlog.address.logic.parser.exceptions.ParseException;
 import wedlog.address.model.person.NameContainsKeywordsPredicate;
 import wedlog.address.model.person.Person;
@@ -106,5 +108,17 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_undo() throws Exception {
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD + " 3") instanceof UndoCommand);
+    }
+
+    @Test
+    public void parseCommand_redo() throws Exception {
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD) instanceof RedoCommand);
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD + " 3") instanceof RedoCommand);
     }
 }

--- a/src/test/java/wedlog/address/model/VersionedAddressBookTest.java
+++ b/src/test/java/wedlog/address/model/VersionedAddressBookTest.java
@@ -1,0 +1,278 @@
+package wedlog.address.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static wedlog.address.testutil.TypicalGuests.GINA;
+import static wedlog.address.testutil.TypicalPersons.AMY;
+import static wedlog.address.testutil.TypicalVendors.ANNE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import wedlog.address.testutil.AddressBookBuilder;
+
+//@@author samuelim01-reused
+// Reused from Address Book(Level 4) with minor modifications.
+class VersionedAddressBookTest {
+
+    private static final ReadOnlyAddressBook EMPTY_ADDRESS_BOOK = new AddressBookBuilder().build();
+    private static final ReadOnlyAddressBook ADDRESS_BOOK_WITH_PERSON_AMY = new AddressBookBuilder()
+            .withPerson(AMY).build();
+    private static final ReadOnlyAddressBook ADDRESS_BOOK_WITH_GUEST_GINA = new AddressBookBuilder()
+            .withGuest(GINA).build();
+    private static final ReadOnlyAddressBook ADDRESS_BOOK_WITH_VENDOR_ANNE = new AddressBookBuilder()
+            .withVendor(ANNE).build();
+
+    @Test
+    public void commit_singleAddressBook_noStatesRemovedCurrentStateSaved() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK);
+
+        versionedAddressBook.commit();
+        assertAddressBookListStatus(versionedAddressBook,
+                Collections.singletonList(EMPTY_ADDRESS_BOOK),
+                EMPTY_ADDRESS_BOOK,
+                Collections.emptyList());
+    }
+
+    @Test
+    public void commit_multipleAddressBooksCurrentStatePointerAtEnd_noStatesRemovedCurrentStateSaved() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+
+        versionedAddressBook.commit();
+        assertAddressBookListStatus(versionedAddressBook,
+                Arrays.asList(EMPTY_ADDRESS_BOOK, ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA),
+                ADDRESS_BOOK_WITH_GUEST_GINA,
+                Collections.emptyList());
+    }
+
+    @Test
+    public void commit_multipleAddressBooksCurrentStatePointerNotAtEnd_statesRemovedCurrentStateSaved() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+
+        shiftCurrentStatePointerLeft(versionedAddressBook, 1);
+        versionedAddressBook.commit();
+        assertAddressBookListStatus(versionedAddressBook,
+                Arrays.asList(EMPTY_ADDRESS_BOOK, ADDRESS_BOOK_WITH_PERSON_AMY),
+                ADDRESS_BOOK_WITH_PERSON_AMY,
+                Collections.emptyList());
+    }
+
+    @Test
+    public void undo_multipleAddressBooksCurrentStatePointerAtEnd_success() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+
+        versionedAddressBook.undo();
+        assertAddressBookListStatus(versionedAddressBook,
+                Collections.singletonList(EMPTY_ADDRESS_BOOK),
+                ADDRESS_BOOK_WITH_PERSON_AMY,
+                Collections.singletonList(ADDRESS_BOOK_WITH_GUEST_GINA));
+    }
+
+    @Test
+    public void undo_multipleAddressBooksCurrentStatePointerNotAtEnd_success() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        shiftCurrentStatePointerLeft(versionedAddressBook, 1);
+
+        versionedAddressBook.undo();
+        assertAddressBookListStatus(versionedAddressBook,
+                Collections.emptyList(),
+                EMPTY_ADDRESS_BOOK,
+                Arrays.asList(ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA));
+    }
+
+    @Test
+    public void undo_multipleAddressBooksCurrentStatePointerAtStart_throwsNoUndoableStateException() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        shiftCurrentStatePointerLeft(versionedAddressBook, 2);
+
+        assertThrows(VersionedAddressBook.NoUndoableStateException.class, () -> versionedAddressBook.undo());
+    }
+
+    @Test
+    public void undo_singleAddressBook_throwsNoUndoableStateException() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK);
+        assertThrows(VersionedAddressBook.NoUndoableStateException.class, () -> versionedAddressBook.undo());
+    }
+
+    @Test
+    public void redo_multipleAddressBooksCurrentStatePointerAtStart_success() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        shiftCurrentStatePointerLeft(versionedAddressBook, 2);
+
+        versionedAddressBook.redo();
+        assertAddressBookListStatus(versionedAddressBook,
+                Collections.singletonList(EMPTY_ADDRESS_BOOK),
+                ADDRESS_BOOK_WITH_PERSON_AMY,
+                Collections.singletonList(ADDRESS_BOOK_WITH_GUEST_GINA));
+    }
+
+    @Test
+    public void redo_multipleAddressBooksCurrentStatePointerNotAtEnd_success() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        shiftCurrentStatePointerLeft(versionedAddressBook, 1);
+
+        versionedAddressBook.redo();
+        assertAddressBookListStatus(versionedAddressBook,
+                Arrays.asList(EMPTY_ADDRESS_BOOK, ADDRESS_BOOK_WITH_PERSON_AMY),
+                ADDRESS_BOOK_WITH_GUEST_GINA,
+                Collections.emptyList());
+    }
+
+    @Test
+    public void redo_multipleAddressBooksCurrentStatePointerAtEnd_throwsNoRedoableException() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+
+        assertThrows(VersionedAddressBook.NoRedoableStateException.class, () -> versionedAddressBook.redo());
+    }
+
+    @Test
+    public void redo_singleAddressBook_throwsNoRedoableException() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK);
+
+        assertThrows(VersionedAddressBook.NoRedoableStateException.class, () -> versionedAddressBook.redo());
+    }
+
+    @Test
+    public void canUndo_multipleAddressBooks_returnsTrue() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        assertTrue(versionedAddressBook.canUndo());
+    }
+
+    @Test
+    public void canUndo_singleAddressBook_returnsFalse() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK);
+        assertFalse(versionedAddressBook.canUndo());
+    }
+
+    @Test
+    public void canUndo_multipleAddressBooksCurrentStatePointerAtStart_returnsFalse() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        shiftCurrentStatePointerLeft(versionedAddressBook, 2);
+        assertFalse(versionedAddressBook.canUndo());
+    }
+
+    @Test
+    public void canRedo_singleAddressBook_returnsFalse() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK);
+        assertFalse(versionedAddressBook.canRedo());
+    }
+
+    @Test
+    public void canRedo_multipleAddressBooksCurrentStatePointerAtStart_returnsTrue() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        shiftCurrentStatePointerLeft(versionedAddressBook, 2);
+        assertTrue(versionedAddressBook.canRedo());
+    }
+
+    @Test
+    public void canRedo_multipleAddressBooksCurrentStatePointerAtMiddle_returnsTrue() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        shiftCurrentStatePointerLeft(versionedAddressBook, 1);
+        assertTrue(versionedAddressBook.canRedo());
+    }
+
+    @Test
+    public void canRedo_multipleAddressBooksCurrentStatePointerAtEnd_returnsFalse() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+
+        assertFalse(versionedAddressBook.canRedo());
+    }
+
+    @Test
+    public void equals() {
+        VersionedAddressBook versionedAddressBook = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+
+        // same object -> returns true
+        assertTrue(versionedAddressBook.equals(versionedAddressBook));
+
+        // same values -> returns true
+        VersionedAddressBook versionedAddressBookCpy = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        assertTrue(versionedAddressBook.equals(versionedAddressBookCpy));
+
+        // different types -> returns false
+        assertFalse(versionedAddressBook.equals(1));
+
+        // null -> returns false
+        assertFalse(versionedAddressBook.equals(null));
+
+        // different state list -> returns false
+        VersionedAddressBook differentStateList = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_VENDOR_ANNE);
+        assertFalse(versionedAddressBook.equals(differentStateList));
+
+        // different current state pointer -> returns false
+        VersionedAddressBook differentStatePointer = prepareVersionedAddressBook(EMPTY_ADDRESS_BOOK,
+                ADDRESS_BOOK_WITH_PERSON_AMY, ADDRESS_BOOK_WITH_GUEST_GINA);
+        shiftCurrentStatePointerLeft(differentStatePointer, 1);
+        assertFalse(versionedAddressBook.equals(differentStatePointer));
+    }
+
+    private void assertAddressBookListStatus(VersionedAddressBook versionedAddressBook,
+                                             List<ReadOnlyAddressBook> expectedStatesBeforePointer,
+                                             ReadOnlyAddressBook expectedCurrentState,
+                                             List<ReadOnlyAddressBook> expectedStatesAfterPointer) {
+
+        // check current state
+        assertEquals(new AddressBook(versionedAddressBook), expectedCurrentState);
+
+        // shift pointer to start of state list
+        while (versionedAddressBook.canUndo()) {
+            versionedAddressBook.undo();
+        }
+
+        // check states before pointer
+        for (ReadOnlyAddressBook expectedState : expectedStatesBeforePointer) {
+            assertEquals(expectedState, new AddressBook(versionedAddressBook));
+            versionedAddressBook.redo();
+        }
+
+        // check states after pointer
+        for (ReadOnlyAddressBook expectedAddressBook : expectedStatesAfterPointer) {
+            versionedAddressBook.redo();
+            assertEquals(expectedAddressBook, new AddressBook(versionedAddressBook));
+        }
+
+        // check that there are no more states after pointer
+        assertFalse(versionedAddressBook.canRedo());
+
+        // revert pointer to original position
+        expectedStatesAfterPointer.forEach(unused -> versionedAddressBook.undo());
+    }
+
+    private VersionedAddressBook prepareVersionedAddressBook(ReadOnlyAddressBook... addressBookStates) {
+        VersionedAddressBook versionedAddressBook = new VersionedAddressBook(addressBookStates[0]);
+
+        for (int i = 1; i < addressBookStates.length; i++) {
+            versionedAddressBook.resetData(addressBookStates[i]);
+            versionedAddressBook.commit();
+        }
+        return versionedAddressBook;
+    }
+
+    private void shiftCurrentStatePointerLeft(VersionedAddressBook versionedAddressBook, int count) {
+        for (int i = 0; i < count; i++) {
+            versionedAddressBook.undo();
+        }
+    }
+}
+//@@author


### PR DESCRIPTION
The application cannot track changes of state in `AddressBook`.

Let's,
- Add VersionedAddressBook that supports keeping track of AddressBook states
- Modify Model and ModelManager to expose VersionedAddressBook operations
- Add UndoCommand and RedoCommand
- Modify state-changing commands to commit to VersionedAddressBook
- Modify Parser to accept UndoCommand and RedoCommand
- Update UG with relevant commands
- Update DG Model diagram

Fixes #81.