### PR TITLE
Wrap optional fields in `Optional`

### DIFF
--- a/src/main/java/wedlog/address/logic/commands/EditCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/EditCommand.java
@@ -96,9 +96,9 @@ public class EditCommand extends Command {
         assert personToEdit != null;
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
-        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
-        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
-        Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone().orElse(null));
+        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail().orElse(null));
+        Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress().orElse(null));
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);

--- a/src/main/java/wedlog/address/logic/parser/GuestAddCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/GuestAddCommandParser.java
@@ -49,15 +49,9 @@ public class GuestAddCommandParser implements Parser<GuestAddCommand> {
 
         // marks the optional fields null if they are empty
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = argMultimap.getValue(PREFIX_PHONE).isEmpty()
-                ? null
-                : ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = argMultimap.getValue(PREFIX_EMAIL).isEmpty()
-                ? null
-                : ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = argMultimap.getValue(PREFIX_ADDRESS).isEmpty()
-                ? null
-                : ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Phone phone = ParserUtil.parseOptionally(argMultimap.getValue(PREFIX_PHONE), ParserUtil::parsePhone);
+        Email email = ParserUtil.parseOptionally(argMultimap.getValue(PREFIX_EMAIL), ParserUtil::parseEmail);
+        Address address = ParserUtil.parseOptionally(argMultimap.getValue(PREFIX_ADDRESS), ParserUtil::parseAddress);
         RsvpStatus rsvpStatus = argMultimap.getValue(PREFIX_RSVP).isEmpty()
                 ? RsvpStatus.unknown() // no input defaults to Status stored as unknown
                 : ParserUtil.parseRsvp(argMultimap.getValue(PREFIX_RSVP).get());

--- a/src/main/java/wedlog/address/logic/parser/ParserUtil.java
+++ b/src/main/java/wedlog/address/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import wedlog.address.commons.core.index.Index;
@@ -161,4 +162,29 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    //@@author samuelim01-reused
+    // Reused from AY2324S1-CS2103T-W08-3
+    // with minor modifications
+    /**
+     * Represents a function that parses the given {@code String} into the given result.
+     */
+    public interface ParserFunction<R> {
+        R parse(String value) throws ParseException;
+    }
+
+    /**
+     * Returns the result of parsing {@code optionalString} with the given
+     * parser function if {@code optionalString} is present, else returns null.
+     */
+    public static <R> R parseOptionally(Optional<String> optionalString, ParserFunction<R> parserFunction)
+            throws ParseException {
+
+        if (optionalString.isPresent()) {
+            return parserFunction.parse(optionalString.get());
+        }
+        return null;
+    }
+
+    //@@author
 }

--- a/src/main/java/wedlog/address/logic/parser/VendorAddCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/VendorAddCommandParser.java
@@ -41,15 +41,9 @@ public class VendorAddCommandParser implements Parser<VendorAddCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME); // throws parse exception if have duplicates
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = argMultimap.getValue(PREFIX_PHONE).isEmpty()
-                ? null
-                : ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = argMultimap.getValue(PREFIX_EMAIL).isEmpty()
-                ? null
-                : ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = argMultimap.getValue(PREFIX_ADDRESS).isEmpty()
-                ? null
-                : ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Phone phone = ParserUtil.parseOptionally(argMultimap.getValue(PREFIX_PHONE), ParserUtil::parsePhone);
+        Email email = ParserUtil.parseOptionally(argMultimap.getValue(PREFIX_EMAIL), ParserUtil::parseEmail);
+        Address address = ParserUtil.parseOptionally(argMultimap.getValue(PREFIX_ADDRESS), ParserUtil::parseAddress);
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
 

--- a/src/main/java/wedlog/address/model/person/Guest.java
+++ b/src/main/java/wedlog/address/model/person/Guest.java
@@ -3,6 +3,7 @@ package wedlog.address.model.person;
 import static wedlog.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import wedlog.address.commons.util.ToStringBuilder;
@@ -17,7 +18,7 @@ public class Guest extends Person {
     // Additional data fields
     private final RsvpStatus rsvpStatus;
     private final DietaryRequirements dietaryRequirements;
-    private final TableNumber tableNumber;
+    private final Optional<TableNumber> tableNumber;
 
     /**
      * Name, rsvp status, dietary requirements and tags must be present and not null.
@@ -29,7 +30,7 @@ public class Guest extends Person {
         this.rsvpStatus = rsvpStatus;
         this.dietaryRequirements =
                 Objects.requireNonNullElseGet(dietaryRequirements, () -> new DietaryRequirements(null));
-        this.tableNumber = tableNumber;
+        this.tableNumber = Optional.ofNullable(tableNumber);
     }
 
     public RsvpStatus getRsvpStatus() {
@@ -40,7 +41,7 @@ public class Guest extends Person {
         return dietaryRequirements;
     }
 
-    public TableNumber getTableNumber() {
+    public Optional<TableNumber> getTableNumber() {
         return tableNumber;
     }
 

--- a/src/main/java/wedlog/address/model/person/Person.java
+++ b/src/main/java/wedlog/address/model/person/Person.java
@@ -5,6 +5,7 @@ import static wedlog.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import wedlog.address.commons.util.ToStringBuilder;
@@ -18,11 +19,11 @@ public class Person {
 
     // Identity fields
     private final Name name;
-    private final Phone phone;
-    private final Email email;
+    private final Optional<Phone> phone;
+    private final Optional<Email> email;
 
     // Data fields
-    private final Address address;
+    private final Optional<Address> address;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
@@ -31,9 +32,9 @@ public class Person {
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
         requireAllNonNull(name, tags);
         this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = address;
+        this.phone = Optional.ofNullable(phone);
+        this.email = Optional.ofNullable(email);
+        this.address = Optional.ofNullable(address);
         this.tags.addAll(tags);
     }
 
@@ -41,15 +42,15 @@ public class Person {
         return name;
     }
 
-    public Phone getPhone() {
+    public Optional<Phone> getPhone() {
         return phone;
     }
 
-    public Email getEmail() {
+    public Optional<Email> getEmail() {
         return email;
     }
 
-    public Address getAddress() {
+    public Optional<Address> getAddress() {
         return address;
     }
 

--- a/src/main/java/wedlog/address/storage/JsonAdaptedGuest.java
+++ b/src/main/java/wedlog/address/storage/JsonAdaptedGuest.java
@@ -3,7 +3,6 @@ package wedlog.address.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -56,7 +55,7 @@ class JsonAdaptedGuest extends JsonAdaptedPerson {
 
         rsvpStatus = source.getRsvpStatus().value;
         dietaryRequirements = source.getDietaryRequirements().value;
-        tableNumber = Optional.ofNullable(source.getTableNumber()).map(tn -> tn.value).orElse(null);
+        tableNumber = source.getTableNumber().map(tn -> tn.value).orElse(null);
     }
 
     /**

--- a/src/main/java/wedlog/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/wedlog/address/storage/JsonAdaptedPerson.java
@@ -3,7 +3,6 @@ package wedlog.address.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -52,9 +51,9 @@ class JsonAdaptedPerson {
      */
     public JsonAdaptedPerson(Person source) {
         name = source.getName().fullName;
-        phone = Optional.ofNullable(source.getPhone()).map(p -> p.value).orElse(null);
-        email = Optional.ofNullable(source.getEmail()).map(e -> e.value).orElse(null);
-        address = Optional.ofNullable(source.getAddress()).map(a -> a.value).orElse(null);
+        phone = source.getPhone().map(p -> p.value).orElse(null);
+        address = source.getAddress().map(a -> a.value).orElse(null);
+        email = source.getEmail().map(e -> e.value).orElse(null);
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/wedlog/address/ui/GuestCard.java
+++ b/src/main/java/wedlog/address/ui/GuestCard.java
@@ -64,7 +64,7 @@ public class GuestCard extends UiPart<Region> {
         phone.setText(guest.getPhone().map(p -> p.value).orElse("-"));
         address.setText(guest.getAddress().map(a -> a.value).orElse("-"));
         email.setText(guest.getEmail().map(e -> e.value).orElse("-"));
-        tableNumber.setText(Optional.ofNullable(guest.getTableNumber()).map(tn -> "table " + tn.value).orElse("-"));
+        tableNumber.setText(guest.getTableNumber().map(tn -> "table " + tn.value).orElse("-"));
 
         // Setting the RSVP Label with conditional styling
         rsvpStatus.setText(Optional.ofNullable(guest.getRsvpStatus()).map(r -> "RSVP: " + r.value).orElse(""));

--- a/src/main/java/wedlog/address/ui/GuestCard.java
+++ b/src/main/java/wedlog/address/ui/GuestCard.java
@@ -59,9 +59,9 @@ public class GuestCard extends UiPart<Region> {
         this.guest = guest;
         id.setText(displayedIndex + ". ");
         name.setText(guest.getName().fullName);
-        phone.setText(Optional.ofNullable(guest.getPhone()).map(p -> p.value).orElse("-"));
-        address.setText(Optional.ofNullable(guest.getAddress()).map(a -> a.value).orElse("-"));
-        email.setText(Optional.ofNullable(guest.getEmail()).map(e -> e.value).orElse("-"));
+        phone.setText(guest.getPhone().map(p -> p.value).orElse("-"));
+        address.setText(guest.getAddress().map(a -> a.value).orElse("-"));
+        email.setText(guest.getEmail().map(e -> e.value).orElse("-"));
 
         // Setting the RSVP Label with conditional styling
         rsvpStatus.setText(Optional.ofNullable(guest.getRsvpStatus()).map(r -> "RSVP: " + r.value).orElse(""));

--- a/src/main/java/wedlog/address/ui/VendorCard.java
+++ b/src/main/java/wedlog/address/ui/VendorCard.java
@@ -1,7 +1,6 @@
 package wedlog.address.ui;
 
 import java.util.Comparator;
-import java.util.Optional;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -50,9 +49,9 @@ public class VendorCard extends UiPart<Region> {
         this.vendor = vendor;
         id.setText(displayedIndex + ". ");
         name.setText(vendor.getName().fullName);
-        phone.setText(Optional.ofNullable(vendor.getPhone()).map(p -> p.value).orElse("-"));
-        address.setText(Optional.ofNullable(vendor.getAddress()).map(a -> a.value).orElse("-"));
-        email.setText(Optional.ofNullable(vendor.getEmail()).map(e -> e.value).orElse("-"));
+        phone.setText(vendor.getPhone().map(p -> p.value).orElse("-"));
+        address.setText(vendor.getAddress().map(a -> a.value).orElse("-"));
+        email.setText(vendor.getEmail().map(e -> e.value).orElse("-"));
         vendor.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
+++ b/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
@@ -31,9 +31,9 @@ public class JsonAdaptedGuestTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = GINA.getName().toString();
-    private static final String VALID_PHONE = GINA.getPhone().toString();
-    private static final String VALID_EMAIL = GINA.getEmail().toString();
-    private static final String VALID_ADDRESS = GINA.getAddress().toString();
+    private static final String VALID_PHONE = GINA.getPhone().get().toString();
+    private static final String VALID_EMAIL = GINA.getEmail().get().toString();
+    private static final String VALID_ADDRESS = GINA.getAddress().get().toString();
     private static final String VALID_RSVP_STATUS = GINA.getRsvpStatus().toString();
     private static final String VALID_YES_RSVP_STATUS = GINA.getRsvpStatus().toString();
     private static final String VALID_NO_RSVP_STATUS = GREG.getRsvpStatus().toString();

--- a/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
+++ b/src/test/java/wedlog/address/storage/JsonAdaptedGuestTest.java
@@ -43,7 +43,7 @@ public class JsonAdaptedGuestTest {
     private static final String VALID_DIETARY_REQUIREMENTS = GINA.getDietaryRequirements().toString();
     private static final String VALID_NONE_DIETARY_REQUIREMENTS = GREG.getDietaryRequirements().toString();
     private static final String VALID_NULL_DIETARY_REQUIREMENTS = GABRIEL.getDietaryRequirements().toString();
-    private static final String VALID_TABLE_NUMBER = GINA.getTableNumber().toString();
+    private static final String VALID_TABLE_NUMBER = GINA.getTableNumber().get().toString();
     private static final String VALID_PRESENT_DIETARY_REQUIREMENTS = GINA.getDietaryRequirements().toString();
 
     private static final List<JsonAdaptedTag> VALID_TAGS = GINA.getTags().stream()

--- a/src/test/java/wedlog/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/wedlog/address/storage/JsonAdaptedPersonTest.java
@@ -27,9 +27,9 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
-    private static final String VALID_PHONE = BENSON.getPhone().toString();
-    private static final String VALID_EMAIL = BENSON.getEmail().toString();
-    private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final String VALID_PHONE = BENSON.getPhone().get().toString();
+    private static final String VALID_EMAIL = BENSON.getEmail().get().toString();
+    private static final String VALID_ADDRESS = BENSON.getAddress().get().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());

--- a/src/test/java/wedlog/address/storage/JsonAdaptedVendorTest.java
+++ b/src/test/java/wedlog/address/storage/JsonAdaptedVendorTest.java
@@ -26,9 +26,9 @@ public class JsonAdaptedVendorTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BRYAN.getName().toString();
-    private static final String VALID_PHONE = BRYAN.getPhone().toString();
-    private static final String VALID_EMAIL = BRYAN.getEmail().toString();
-    private static final String VALID_ADDRESS = BRYAN.getAddress().toString();
+    private static final String VALID_PHONE = BRYAN.getPhone().get().toString();
+    private static final String VALID_EMAIL = BRYAN.getEmail().get().toString();
+    private static final String VALID_ADDRESS = BRYAN.getAddress().get().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BRYAN.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());

--- a/src/test/java/wedlog/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/wedlog/address/testutil/EditPersonDescriptorBuilder.java
@@ -33,9 +33,9 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder(Person person) {
         descriptor = new EditPersonDescriptor();
         descriptor.setName(person.getName());
-        descriptor.setPhone(person.getPhone());
-        descriptor.setEmail(person.getEmail());
-        descriptor.setAddress(person.getAddress());
+        descriptor.setPhone(person.getPhone().orElse(null));
+        descriptor.setEmail(person.getEmail().orElse(null));
+        descriptor.setAddress(person.getAddress().orElse(null));
         descriptor.setTags(person.getTags());
     }
 

--- a/src/test/java/wedlog/address/testutil/GuestBuilder.java
+++ b/src/test/java/wedlog/address/testutil/GuestBuilder.java
@@ -74,7 +74,7 @@ public class GuestBuilder {
         address = guestToCopy.getAddress().orElse(null);
         rsvpStatus = guestToCopy.getRsvpStatus();
         dietaryRequirements = guestToCopy.getDietaryRequirements();
-        tableNumber = guestToCopy.getTableNumber();
+        tableNumber = guestToCopy.getTableNumber().orElse(null);
         tags = new HashSet<>(guestToCopy.getTags());
     }
 

--- a/src/test/java/wedlog/address/testutil/GuestBuilder.java
+++ b/src/test/java/wedlog/address/testutil/GuestBuilder.java
@@ -64,9 +64,9 @@ public class GuestBuilder {
      */
     public GuestBuilder(Guest guestToCopy) {
         name = guestToCopy.getName();
-        phone = guestToCopy.getPhone();
-        email = guestToCopy.getEmail();
-        address = guestToCopy.getAddress();
+        phone = guestToCopy.getPhone().orElse(null);
+        email = guestToCopy.getEmail().orElse(null);
+        address = guestToCopy.getAddress().orElse(null);
         rsvpStatus = guestToCopy.getRsvpStatus();
         dietaryRequirements = guestToCopy.getDietaryRequirements();
         tags = new HashSet<>(guestToCopy.getTags());

--- a/src/test/java/wedlog/address/testutil/GuestUtil.java
+++ b/src/test/java/wedlog/address/testutil/GuestUtil.java
@@ -31,7 +31,7 @@ public class GuestUtil {
         sb.append(PREFIX_ADDRESS + guest.getAddress().map(a -> a.value).orElse("") + " ");
         sb.append(PREFIX_RSVP + guest.getRsvpStatus().toString() + " ");
         sb.append(PREFIX_DIETARY + guest.getDietaryRequirements().value + " ");
-        sb.append(PREFIX_TABLE + guest.getTableNumber().value + " ");
+        sb.append(PREFIX_TABLE + guest.getTableNumber().map(tn -> tn.value).orElse("") + " ");
         guest.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );

--- a/src/test/java/wedlog/address/testutil/GuestUtil.java
+++ b/src/test/java/wedlog/address/testutil/GuestUtil.java
@@ -25,9 +25,9 @@ public class GuestUtil {
     public static String getGuestDetails(Guest guest) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NAME + guest.getName().fullName + " ");
-        sb.append(PREFIX_PHONE + guest.getPhone().value + " ");
-        sb.append(PREFIX_EMAIL + guest.getEmail().value + " ");
-        sb.append(PREFIX_ADDRESS + guest.getAddress().value + " ");
+        sb.append(PREFIX_PHONE + guest.getPhone().map(p -> p.value).orElse("") + " ");
+        sb.append(PREFIX_EMAIL + guest.getEmail().map(e -> e.value).orElse("") + " ");
+        sb.append(PREFIX_ADDRESS + guest.getAddress().map(a -> a.value).orElse("") + " ");
         sb.append(PREFIX_RSVP + guest.getRsvpStatus().toString() + " ");
         sb.append(PREFIX_DIETARY + guest.getDietaryRequirements().value + " ");
         guest.getTags().stream().forEach(

--- a/src/test/java/wedlog/address/testutil/PersonBuilder.java
+++ b/src/test/java/wedlog/address/testutil/PersonBuilder.java
@@ -43,9 +43,9 @@ public class PersonBuilder {
      */
     public PersonBuilder(Person personToCopy) {
         name = personToCopy.getName();
-        phone = personToCopy.getPhone();
-        email = personToCopy.getEmail();
-        address = personToCopy.getAddress();
+        phone = personToCopy.getPhone().orElse(null);
+        email = personToCopy.getEmail().orElse(null);
+        address = personToCopy.getAddress().orElse(null);
         tags = new HashSet<>(personToCopy.getTags());
     }
 

--- a/src/test/java/wedlog/address/testutil/PersonUtil.java
+++ b/src/test/java/wedlog/address/testutil/PersonUtil.java
@@ -24,9 +24,9 @@ public class PersonUtil {
     public static String getPersonDetails(Person person) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
-        sb.append(PREFIX_PHONE + person.getPhone().value + " ");
-        sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
-        sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
+        sb.append(PREFIX_PHONE + person.getPhone().map(p -> p.value).orElse(null) + " ");
+        sb.append(PREFIX_EMAIL + person.getEmail().map(e -> e.value).orElse(null) + " ");
+        sb.append(PREFIX_ADDRESS + person.getAddress().map(a -> a.value).orElse(null) + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );

--- a/src/test/java/wedlog/address/testutil/VendorBuilder.java
+++ b/src/test/java/wedlog/address/testutil/VendorBuilder.java
@@ -54,9 +54,9 @@ public class VendorBuilder {
      */
     public VendorBuilder(Vendor vendorToCopy) {
         name = vendorToCopy.getName();
-        phone = vendorToCopy.getPhone();
-        email = vendorToCopy.getEmail();
-        address = vendorToCopy.getAddress();
+        phone = vendorToCopy.getPhone().orElse(null);
+        email = vendorToCopy.getEmail().orElse(null);
+        address = vendorToCopy.getAddress().orElse(null);
         tags = new HashSet<>(vendorToCopy.getTags());
     }
 

--- a/src/test/java/wedlog/address/testutil/VendorUtil.java
+++ b/src/test/java/wedlog/address/testutil/VendorUtil.java
@@ -23,9 +23,9 @@ public class VendorUtil {
     public static String getVendorDetails(Vendor vendor) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NAME + vendor.getName().fullName + " ");
-        sb.append(PREFIX_PHONE + vendor.getPhone().value + " ");
-        sb.append(PREFIX_EMAIL + vendor.getEmail().value + " ");
-        sb.append(PREFIX_ADDRESS + vendor.getAddress().value + " ");
+        sb.append(PREFIX_PHONE + vendor.getPhone().map(p -> p.value).orElse("") + " ");
+        sb.append(PREFIX_EMAIL + vendor.getEmail().map(e -> e.value).orElse("") + " ");
+        sb.append(PREFIX_ADDRESS + vendor.getAddress().map(a -> a.value).orElse("") + " ");
         vendor.getTags().stream().forEach(
                 s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );


### PR DESCRIPTION
Phone, Email, and Address are optional fields in Person, represented as null if the Person does not have that field. TableNumber is an optional field implemented similarly in Guest.

Let's wrap the fields in Optional, e.g. from Phone to Optional<Phone>. If the Person does not have that field, it is stored as Optional#empty().

This makes it clearer which fields in Person are optional, and enforces that the absence of the field is handled in relevant methods.