### PR TITLE
Improve testcases for `vendor add` and `guest add` commands

### DIFF
--- a/src/main/java/wedlog/address/logic/parser/GuestAddCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/GuestAddCommandParser.java
@@ -46,8 +46,9 @@ public class GuestAddCommandParser implements Parser<GuestAddCommand> {
             // message usage is a generic message about how to use the add command for guests
         }
 
-        // throws parse exception if name is inputted twice
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME);
+        // throws parse exception if any field (except tags) is inputted twice
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_RSVP,
+                PREFIX_DIETARY, PREFIX_TABLE);
 
         // marks the optional fields null if they are empty
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());

--- a/src/main/java/wedlog/address/logic/parser/VendorAddCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/VendorAddCommandParser.java
@@ -38,7 +38,8 @@ public class VendorAddCommandParser implements Parser<VendorAddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, VendorAddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME); // throws parse exception if have duplicates
+        // throws parse exception if any field (except tags) is inputted twice
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = argMultimap.getValue(PREFIX_PHONE).isEmpty()

--- a/src/main/java/wedlog/address/model/person/Phone.java
+++ b/src/main/java/wedlog/address/model/person/Phone.java
@@ -12,7 +12,7 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+    public static final String VALIDATION_REGEX = "^\\d{3,}$";
     public final String value;
 
     /**

--- a/src/test/java/wedlog/address/logic/LogicManagerTest.java
+++ b/src/test/java/wedlog/address/logic/LogicManagerTest.java
@@ -3,15 +3,15 @@ package wedlog.address.logic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static wedlog.address.logic.Messages.MESSAGE_INVALID_GUEST_DISPLAYED_INDEX;
 import static wedlog.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.DIETARY_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.RSVP_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.TABLE_DESC_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.DIETARY_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.RSVP_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.TABLE_DESC_GIA;
 import static wedlog.address.testutil.Assert.assertThrows;
-import static wedlog.address.testutil.TypicalGuests.AMY;
+import static wedlog.address.testutil.TypicalGuests.GIA;
 import static wedlog.address.testutil.TypicalGuests.GINA;
 import static wedlog.address.testutil.TypicalGuests.GREG;
 
@@ -183,9 +183,9 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing a guest add command
-        String guestAddCommand = "guest " + GuestAddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + RSVP_DESC_AMY + DIETARY_DESC_AMY + TABLE_DESC_AMY;
-        Guest expectedGuest = new GuestBuilder(AMY).withTags().build();
+        String guestAddCommand = "guest " + GuestAddCommand.COMMAND_WORD + NAME_DESC_GIA + PHONE_DESC_GIA
+                + EMAIL_DESC_GIA + ADDRESS_DESC_GIA + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA;
+        Guest expectedGuest = new GuestBuilder(GIA).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addGuest(expectedGuest);
         expectedModel.commitAddressBook();

--- a/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
@@ -30,40 +30,77 @@ import wedlog.address.testutil.EditPersonDescriptorBuilder;
  * Contains helper methods for testing commands.
  */
 public class CommandTestUtil {
-
+    // Names
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
+    public static final String VALID_NAME_GIA = "Gia Giordano";
+    public static final String VALID_NAME_VAL = "Val Valencia";
+
+    // Phone
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_GIA = "33333333";
+    public static final String VALID_PHONE_VAL = "44444444";
+
+    // Email
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
+    public static final String VALID_EMAIL_GIA = "gia@example.com";
+    public static final String VALID_EMAIL_VAL = "val@example.com";
+
+    // Address
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
+    public static final String VALID_ADDRESS_GIA = "Block 456, Gia Street 5";
+    public static final String VALID_ADDRESS_VAL = "Block 456, Val Street 7";
+
+    // RSVP
     public static final String VALID_RSVP_STATUS_AMY = "no";
     public static final String VALID_RSVP_STATUS_BOB = "unknown";
+    public static final String VALID_RSVP_STATUS_GIA = "yes";
+
+    // Dietary Requirement
     public static final String VALID_DIETARY_REQUIREMENTS_AMY = "none";
     public static final String VALID_DIETARY_REQUIREMENTS_BOB = "no beef";
+    public static final String VALID_DIETARY_REQUIREMENTS_GIA = "vegan";
+
+    // Table Number
     public static final String VALID_TABLE_NUMBER_AMY = "13";
     public static final String VALID_TABLE_NUMBER_BOB = "31";
+    public static final String VALID_TABLE_NUMBER_GIA = "57";
+
+    // Tags
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_TAG_FLORIST = "florist";
     public static final String VALID_TAG_PHOTOGRAPHER = "photographer";
 
+    // With prefixes
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
+    public static final String NAME_DESC_GIA = " " + PREFIX_NAME + VALID_NAME_GIA;
+    public static final String NAME_DESC_VAL = " " + PREFIX_NAME + VALID_NAME_VAL;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
+    public static final String PHONE_DESC_GIA = " " + PREFIX_PHONE + VALID_PHONE_GIA;
+    public static final String PHONE_DESC_VAL = " " + PREFIX_PHONE + VALID_PHONE_VAL;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
+    public static final String EMAIL_DESC_GIA = " " + PREFIX_EMAIL + VALID_EMAIL_GIA;
+    public static final String EMAIL_DESC_VAL = " " + PREFIX_EMAIL + VALID_EMAIL_VAL;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String ADDRESS_DESC_GIA = " " + PREFIX_ADDRESS + VALID_ADDRESS_GIA;
+    public static final String ADDRESS_DESC_VAL = " " + PREFIX_ADDRESS + VALID_ADDRESS_VAL;
     public static final String RSVP_DESC_AMY = " " + PREFIX_RSVP + VALID_RSVP_STATUS_AMY;
     public static final String RSVP_DESC_BOB = " " + PREFIX_RSVP + VALID_RSVP_STATUS_BOB;
+    public static final String RSVP_DESC_GIA = " " + PREFIX_RSVP + VALID_RSVP_STATUS_GIA;
     public static final String DIETARY_DESC_AMY = " " + PREFIX_DIETARY + VALID_DIETARY_REQUIREMENTS_AMY;
     public static final String DIETARY_DESC_BOB = " " + PREFIX_DIETARY + VALID_DIETARY_REQUIREMENTS_BOB;
+    public static final String DIETARY_DESC_GIA = " " + PREFIX_DIETARY + VALID_DIETARY_REQUIREMENTS_GIA;
     public static final String TABLE_DESC_AMY = " " + PREFIX_TABLE + VALID_TABLE_NUMBER_AMY;
     public static final String TABLE_DESC_BOB = " " + PREFIX_TABLE + VALID_TABLE_NUMBER_BOB;
+    public static final String TABLE_DESC_GIA = " " + PREFIX_TABLE + VALID_TABLE_NUMBER_GIA;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String TAG_DESC_FLORIST = " " + PREFIX_TAG + VALID_TAG_FLORIST;

--- a/src/test/java/wedlog/address/logic/parser/GuestAddCommandParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/GuestAddCommandParserTest.java
@@ -3,12 +3,9 @@ package wedlog.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static wedlog.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.DIETARY_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.DIETARY_DESC_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.DIETARY_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
@@ -17,23 +14,18 @@ import static wedlog.address.logic.commands.CommandTestUtil.INVALID_RSVP_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_TABLE_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
-import static wedlog.address.logic.commands.CommandTestUtil.RSVP_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.RSVP_DESC_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.TABLE_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.TABLE_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.RSVP_DESC_GIA;
+import static wedlog.address.logic.commands.CommandTestUtil.TABLE_DESC_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static wedlog.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static wedlog.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static wedlog.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static wedlog.address.testutil.TypicalGuests.AMY;
-import static wedlog.address.testutil.TypicalGuests.BOB;
+import static wedlog.address.testutil.TypicalGuests.GIA;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +37,7 @@ import wedlog.address.model.person.Guest;
 import wedlog.address.model.person.Name;
 import wedlog.address.model.person.Phone;
 import wedlog.address.model.person.RsvpStatus;
+import wedlog.address.model.person.TableNumber;
 import wedlog.address.model.tag.Tag;
 import wedlog.address.testutil.GuestBuilder;
 
@@ -53,38 +46,109 @@ public class GuestAddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() throws ParseException {
-        GuestAddCommand guestAddCommand = parser.parse(NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY + RSVP_DESC_AMY + DIETARY_DESC_AMY + TABLE_DESC_AMY + TAG_DESC_FRIEND);
-        assertEquals(guestAddCommand, new GuestAddCommand(AMY));
+        GuestAddCommand guestAddCommand = parser.parse(NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA
+                + ADDRESS_DESC_GIA + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_FRIEND);
+        assertEquals(guestAddCommand, new GuestAddCommand(GIA));
     }
 
     @Test
     public void parse_onlyNamePresent_success() throws ParseException {
-        Guest expectedGuest = new GuestBuilder(VALID_NAME_AMY).build();
-        GuestAddCommand guestAddCommand = parser.parse(NAME_DESC_AMY);
+        Guest expectedGuest = new GuestBuilder(VALID_NAME_GIA).build();
+        GuestAddCommand guestAddCommand = parser.parse(NAME_DESC_GIA);
         assertEquals(new GuestAddCommand(expectedGuest), guestAddCommand);
     }
 
     @Test
-    public void parse_repeatedNameValue_failure() throws ParseException {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+    public void parse_repeatedNameValue_failure() {
+        String validExpectedPersonString = NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA
+                + ADDRESS_DESC_GIA + TAG_DESC_FRIEND;
 
         assertThrows(ParseException.class, () -> parser.parse(NAME_DESC_AMY + validExpectedPersonString));
     }
 
+    /**
+     * Tests instance where a field has an invalid value (with no valid value present).
+     */
     @Test
-    public void parse_invalidValues_failure() throws ParseException {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid phone
+        assertParseFailure(parser, NAME_DESC_GIA + INVALID_PHONE_DESC + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Phone.MESSAGE_CONSTRAINTS);
+
+        // invalid email
+        assertParseFailure(parser, NAME_DESC_GIA + PHONE_DESC_GIA + INVALID_EMAIL_DESC + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Email.MESSAGE_CONSTRAINTS);
+
+        // invalid address
+        assertParseFailure(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + INVALID_ADDRESS_DESC
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Address.MESSAGE_CONSTRAINTS);
+
+        // invalid rsvp
+        assertParseFailure(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + INVALID_RSVP_DESC + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                RsvpStatus.MESSAGE_CONSTRAINTS);
+
+        // invalid dietary requirement does not exist
+
+        // invalid table number
+        assertParseFailure(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + INVALID_TABLE_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                TableNumber.MESSAGE_CONSTRAINTS);
+
+        // invalid tag
+        assertParseFailure(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + INVALID_TAG_DESC + VALID_TAG_FRIEND,
+                Tag.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_GIA + EMAIL_DESC_GIA + INVALID_ADDRESS_DESC
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA
+                        + ADDRESS_DESC_GIA + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_HUSBAND
+                        + TAG_DESC_FRIEND,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, GuestAddCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests instance where a field has an invalid value (with a valid value before / after).
+     */
+    @Test
+    public void parse_invalidValuesWithValidValues_failure() throws ParseException {
+        String validExpectedPersonString = NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_FRIEND;
 
         // invalid value followed by valid value
 
         // invalid name
         assertThrows(ParseException.class, () -> parser.parse(INVALID_NAME_DESC + validExpectedPersonString));
 
+        // invalid phone
+        assertThrows(ParseException.class, () -> parser.parse(INVALID_PHONE_DESC + validExpectedPersonString));
+
         // invalid email
         assertThrows(ParseException.class, () -> parser.parse(INVALID_EMAIL_DESC + validExpectedPersonString));
+
+        // invalid address
+        assertThrows(ParseException.class, () -> parser.parse(INVALID_ADDRESS_DESC + validExpectedPersonString));
+
+        // invalid rsvp
+        assertThrows(ParseException.class, () -> parser.parse(INVALID_RSVP_DESC + validExpectedPersonString));
+
+        // invalid dietary requirement does not exist
+
+        // invalid table number
+        assertThrows(ParseException.class, () -> parser.parse(INVALID_TABLE_DESC + validExpectedPersonString));
 
 
         // valid value followed by invalid value
@@ -92,11 +156,11 @@ public class GuestAddCommandParserTest {
         // invalid name
         assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_NAME_DESC));
 
-        // invalid email
-        assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_EMAIL_DESC));
-
         // invalid phone
         assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_PHONE_DESC));
+
+        // invalid email
+        assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_EMAIL_DESC));
 
         // invalid address
         assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_ADDRESS_DESC));
@@ -104,66 +168,10 @@ public class GuestAddCommandParserTest {
         // invalid rsvp
         assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_RSVP_DESC));
 
+        // invalid dietary requirement does not exist
+
         // invalid table number
         assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_TABLE_DESC));
-    }
-
-    @Test
-    public void parse_missingTags_success() {
-        // zero tags
-        Guest expectedGuest = new GuestBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                        + RSVP_DESC_AMY + DIETARY_DESC_AMY + TABLE_DESC_AMY,
-                new GuestAddCommand(expectedGuest));
-    }
-
-    @Test
-    public void parse_missingPhone_success() {
-        Guest expectedGuest = new GuestBuilder(BOB).withoutPhone().build();
-        assertParseSuccess(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + RSVP_DESC_BOB + DIETARY_DESC_BOB + TABLE_DESC_BOB + TAG_DESC_FRIEND
-                + TAG_DESC_HUSBAND, new GuestAddCommand(expectedGuest));
-    }
-
-    @Test
-    public void parse_missingEmail_success() {
-
-        Guest expectedGuest = new GuestBuilder(BOB).withoutEmail().build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB
-                + RSVP_DESC_BOB + DIETARY_DESC_BOB + TABLE_DESC_BOB + TAG_DESC_FRIEND
-                + TAG_DESC_HUSBAND, new GuestAddCommand(expectedGuest));
-    }
-
-    @Test
-    public void parse_missingAddress_success() {
-        Guest expectedGuest = new GuestBuilder(BOB).withoutAddress().build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + RSVP_DESC_BOB + DIETARY_DESC_BOB + TABLE_DESC_BOB + TAG_DESC_FRIEND
-                + TAG_DESC_HUSBAND, new GuestAddCommand(expectedGuest));
-    }
-
-    @Test
-    public void parse_missingRsvp_success() {
-        Guest expectedGuest = new GuestBuilder(BOB).withUnknownRsvpStatus().build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + DIETARY_DESC_BOB + TABLE_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
-                new GuestAddCommand(expectedGuest));
-    }
-
-    @Test
-    public void parse_missingDietaryRequirement_success() {
-        Guest expectedGuest = new GuestBuilder(BOB).withNullDietaryRequirements().build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + RSVP_DESC_BOB + TABLE_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
-                new GuestAddCommand(expectedGuest));
-    }
-
-    @Test
-    public void parse_missingTableNumber_success() {
-        Guest expectedGuest = new GuestBuilder(BOB).withoutTableNumber().build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + RSVP_DESC_BOB + DIETARY_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
-                new GuestAddCommand(expectedGuest));
     }
 
     @Test
@@ -171,43 +179,65 @@ public class GuestAddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, GuestAddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+        assertParseFailure(parser, VALID_NAME_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA,
                 expectedMessage);
     }
 
     @Test
-    public void parse_invalidValue_failure() {
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+    public void parse_missingPhone_success() {
+        Guest expectedGuest = new GuestBuilder(GIA).withoutPhone().build();
+        assertParseSuccess(parser, NAME_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_FRIEND,
+                new GuestAddCommand(expectedGuest));
+    }
 
-        // invalid phone
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+    @Test
+    public void parse_missingEmail_success() {
 
-        // invalid email
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+        Guest expectedGuest = new GuestBuilder(GIA).withoutEmail().build();
+        assertParseSuccess(parser, NAME_DESC_GIA + PHONE_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_FRIEND,
+                new GuestAddCommand(expectedGuest));
+    }
 
-        // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+    @Test
+    public void parse_missingAddress_success() {
+        Guest expectedGuest = new GuestBuilder(GIA).withoutAddress().build();
+        assertParseSuccess(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_FRIEND,
+                new GuestAddCommand(expectedGuest));
+    }
 
-        // invalid rsvp
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_RSVP_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, RsvpStatus.MESSAGE_CONSTRAINTS);
+    @Test
+    public void parse_missingRsvp_success() {
+        Guest expectedGuest = new GuestBuilder(GIA).withUnknownRsvpStatus().build();
+        assertParseSuccess(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + DIETARY_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_FRIEND,
+                new GuestAddCommand(expectedGuest));
+    }
 
-        // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+    @Test
+    public void parse_missingDietaryRequirement_success() {
+        Guest expectedGuest = new GuestBuilder(GIA).withNullDietaryRequirements().build();
+        assertParseSuccess(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + TABLE_DESC_GIA + TAG_DESC_FRIEND,
+                new GuestAddCommand(expectedGuest));
+    }
 
-        // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
-                Name.MESSAGE_CONSTRAINTS);
+    @Test
+    public void parse_missingTableNumber_success() {
+        Guest expectedGuest = new GuestBuilder(GIA).withoutTableNumber().build();
+        assertParseSuccess(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                + RSVP_DESC_GIA + DIETARY_DESC_GIA + TAG_DESC_FRIEND,
+                new GuestAddCommand(expectedGuest));
+    }
 
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, GuestAddCommand.MESSAGE_USAGE));
+    @Test
+    public void parse_missingTags_success() {
+        // zero tags
+        Guest expectedGuest = new GuestBuilder(GIA).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_GIA + PHONE_DESC_GIA + EMAIL_DESC_GIA + ADDRESS_DESC_GIA
+                        + RSVP_DESC_GIA + DIETARY_DESC_GIA + TABLE_DESC_GIA,
+                new GuestAddCommand(expectedGuest));
     }
 }

--- a/src/test/java/wedlog/address/logic/parser/VendorAddCommandParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/VendorAddCommandParserTest.java
@@ -3,28 +3,25 @@ package wedlog.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static wedlog.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.ADDRESS_DESC_VAL;
+import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_VAL;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.NAME_DESC_VAL;
+import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_VAL;
 import static wedlog.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static wedlog.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static wedlog.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.TAG_DESC_PHOTOGRAPHER;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_VAL;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static wedlog.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static wedlog.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static wedlog.address.testutil.TypicalVendors.AMY;
+import static wedlog.address.testutil.TypicalVendors.VAL;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,44 +33,89 @@ import wedlog.address.model.person.Name;
 import wedlog.address.model.person.Phone;
 import wedlog.address.model.person.Vendor;
 import wedlog.address.model.tag.Tag;
+import wedlog.address.testutil.TypicalVendors;
 import wedlog.address.testutil.VendorBuilder;
 
 public class VendorAddCommandParserTest {
     private VendorAddCommandParser parser = new VendorAddCommandParser();
     @Test
     public void parse_allFieldsPresent_success() throws ParseException {
-        VendorAddCommand vendorAddCommand = parser.parse(NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY);
-        assertEquals(vendorAddCommand, new VendorAddCommand(AMY));
+        VendorAddCommand vendorAddCommand = parser.parse(NAME_DESC_VAL + PHONE_DESC_VAL + EMAIL_DESC_VAL
+                + ADDRESS_DESC_VAL + TAG_DESC_PHOTOGRAPHER);
+        assertEquals(vendorAddCommand, new VendorAddCommand(VAL));
     }
 
     @Test
     public void parse_onlyNamePresent_success() throws ParseException {
-        Vendor expectedVendor = new VendorBuilder(VALID_NAME_AMY).build();
-        VendorAddCommand vendorAddCommand = parser.parse(NAME_DESC_AMY);
+        Vendor expectedVendor = new VendorBuilder(VALID_NAME_VAL).build();
+        VendorAddCommand vendorAddCommand = parser.parse(NAME_DESC_VAL);
         assertEquals(new VendorAddCommand(expectedVendor), vendorAddCommand);
     }
 
     @Test
-    public void parse_repeatedNameValue_failure() throws ParseException {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+    public void parse_repeatedNameValue_failure() {
+        String validExpectedPersonString = NAME_DESC_VAL + PHONE_DESC_VAL + EMAIL_DESC_VAL
+                + ADDRESS_DESC_VAL + TAG_DESC_FRIEND;
 
-        assertThrows(ParseException.class, () -> parser.parse(NAME_DESC_AMY + validExpectedPersonString));
+        assertThrows(ParseException.class, () -> parser.parse(NAME_DESC_BOB + validExpectedPersonString));
     }
 
+    /**
+     * Tests instance where a field has an invalid value (with no valid value present).
+     */
     @Test
-    public void parse_invalidValues_failure() throws ParseException {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_VAL + EMAIL_DESC_VAL + ADDRESS_DESC_VAL
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid phone
+        assertParseFailure(parser, NAME_DESC_VAL + INVALID_PHONE_DESC + EMAIL_DESC_VAL + ADDRESS_DESC_VAL
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+
+        // invalid email
+        assertParseFailure(parser, NAME_DESC_VAL + PHONE_DESC_VAL + INVALID_EMAIL_DESC + ADDRESS_DESC_VAL
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+
+        // invalid address
+        assertParseFailure(parser, NAME_DESC_VAL + PHONE_DESC_VAL + EMAIL_DESC_VAL + INVALID_ADDRESS_DESC
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+
+        // invalid tag
+        assertParseFailure(parser, NAME_DESC_VAL + PHONE_DESC_VAL + EMAIL_DESC_VAL + ADDRESS_DESC_VAL
+                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_VAL + EMAIL_DESC_VAL + INVALID_ADDRESS_DESC,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_VAL + PHONE_DESC_VAL + EMAIL_DESC_VAL
+                        + ADDRESS_DESC_VAL + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, VendorAddCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests instance where a field has an invalid value (with a valid value before / after).
+     */
+    @Test
+    public void parse_invalidValuesWithValidValues_failure() {
+        String validExpectedPersonString = NAME_DESC_VAL + PHONE_DESC_VAL
+                + ADDRESS_DESC_VAL + TAG_DESC_FRIEND;
 
         // invalid value followed by valid value
 
         // invalid name
         assertThrows(ParseException.class, () -> parser.parse(INVALID_NAME_DESC + validExpectedPersonString));
 
+        // invalid phone
+        assertThrows(ParseException.class, () -> parser.parse(INVALID_PHONE_DESC + validExpectedPersonString));
+
         // invalid email
         assertThrows(ParseException.class, () -> parser.parse(INVALID_EMAIL_DESC + validExpectedPersonString));
+
+        // invalid address
+        assertThrows(ParseException.class, () -> parser.parse(INVALID_ADDRESS_DESC + validExpectedPersonString));
 
 
         // valid value followed by invalid value
@@ -81,11 +123,11 @@ public class VendorAddCommandParserTest {
         // invalid name
         assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_NAME_DESC));
 
-        // invalid email
-        assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_EMAIL_DESC));
-
         // invalid phone
         assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_PHONE_DESC));
+
+        // invalid email
+        assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_EMAIL_DESC));
 
         // invalid address
         assertThrows(ParseException.class, () -> parser.parse(validExpectedPersonString + INVALID_ADDRESS_DESC));
@@ -93,49 +135,40 @@ public class VendorAddCommandParserTest {
     }
 
     @Test
-    public void parse_onlyName_success() {
-        Vendor expectedVendor = new VendorBuilder("Bob Choo").build();
-        assertParseSuccess(parser, NAME_DESC_BOB, new VendorAddCommand(expectedVendor));
-    }
-
-    @Test
-    public void parse_compulsoryFieldMissing_failure() {
+    public void parse_compulsoryNameFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, VendorAddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+        assertParseFailure(parser, VALID_NAME_VAL + PHONE_DESC_VAL + EMAIL_DESC_VAL + ADDRESS_DESC_VAL,
                 expectedMessage);
     }
 
     @Test
-    public void parse_invalidValue_failure() {
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+    public void parse_missingPhone_success() {
+        Vendor expectedVendor = new VendorBuilder(VAL).withoutPhone().build();
+        assertParseSuccess(parser, NAME_DESC_VAL + EMAIL_DESC_VAL + ADDRESS_DESC_VAL
+                + TAG_DESC_PHOTOGRAPHER, new VendorAddCommand(expectedVendor));
+    }
 
-        // invalid phone
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+    @Test
+    public void parse_missingEmail_success() {
+        Vendor expectedVendor = new VendorBuilder(VAL).withoutEmail().build();
+        assertParseSuccess(parser, NAME_DESC_VAL + PHONE_DESC_VAL + ADDRESS_DESC_VAL
+                + TAG_DESC_PHOTOGRAPHER, new VendorAddCommand(expectedVendor));
+    }
 
-        // invalid email
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+    @Test
+    public void parse_missingAddress_success() {
+        Vendor expectedVendor = new VendorBuilder(VAL).withoutAddress().build();
+        assertParseSuccess(parser, NAME_DESC_VAL + PHONE_DESC_VAL + EMAIL_DESC_VAL
+                + TAG_DESC_PHOTOGRAPHER, new VendorAddCommand(expectedVendor));
+    }
 
-        // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
-
-        // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
-
-        // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
-                Name.MESSAGE_CONSTRAINTS);
-
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, VendorAddCommand.MESSAGE_USAGE));
+    @Test
+    public void parse_missingTags_success() {
+        // zero tags
+        Vendor expectedVendor = new VendorBuilder(TypicalVendors.VAL).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_VAL + PHONE_DESC_VAL + EMAIL_DESC_VAL + ADDRESS_DESC_VAL,
+                new VendorAddCommand(expectedVendor));
     }
 }

--- a/src/test/java/wedlog/address/testutil/TypicalGuests.java
+++ b/src/test/java/wedlog/address/testutil/TypicalGuests.java
@@ -1,19 +1,19 @@
 package wedlog.address.testutil;
 
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_DIETARY_REQUIREMENTS_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_DIETARY_REQUIREMENTS_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_DIETARY_REQUIREMENTS_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_EMAIL_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_RSVP_STATUS_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_PHONE_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_RSVP_STATUS_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_TABLE_NUMBER_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_RSVP_STATUS_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_TABLE_NUMBER_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_TABLE_NUMBER_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
@@ -58,9 +58,11 @@ public class TypicalGuests {
             .build();
 
     // Manually added - Guest's details found in {@code CommandTestUtil}
-    public static final Guest AMY = new GuestBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withRsvpStatus(VALID_RSVP_STATUS_AMY)
-            .withDietaryRequirements(VALID_DIETARY_REQUIREMENTS_AMY).withTableNumber(VALID_TABLE_NUMBER_AMY)
+
+
+    public static final Guest GIA = new GuestBuilder().withName(VALID_NAME_GIA).withPhone(VALID_PHONE_GIA)
+            .withEmail(VALID_EMAIL_GIA).withAddress(VALID_ADDRESS_GIA).withRsvpStatus(VALID_RSVP_STATUS_GIA)
+            .withDietaryRequirements(VALID_DIETARY_REQUIREMENTS_GIA).withTableNumber(VALID_TABLE_NUMBER_GIA)
             .withTags(VALID_TAG_FRIEND).build();
     public static final Guest BOB = new GuestBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withRsvpStatus(VALID_RSVP_STATUS_BOB)

--- a/src/test/java/wedlog/address/testutil/TypicalVendors.java
+++ b/src/test/java/wedlog/address/testutil/TypicalVendors.java
@@ -1,14 +1,15 @@
 package wedlog.address.testutil;
 
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_VAL;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_EMAIL_VAL;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static wedlog.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_NAME_VAL;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_PHONE_VAL;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_FLORIST;
+import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_PHOTOGRAPHER;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,8 +49,8 @@ public class TypicalVendors {
             .withEmail("muellerirene@example.com").withAddress("chicago ave").build();
 
     // Manually added - Vendor's details found in {@code CommandTestUtil}
-    public static final Vendor AMY = new VendorBuilder(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).build();
+    public static final Vendor VAL = new VendorBuilder(VALID_NAME_VAL).withPhone(VALID_PHONE_VAL)
+            .withEmail(VALID_EMAIL_VAL).withAddress(VALID_ADDRESS_VAL).withTags(VALID_TAG_PHOTOGRAPHER).build();
     public static final Vendor BOB = new VendorBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FLORIST)
             .build();


### PR DESCRIPTION
Resolves #125.

Testcases for `vendor add` and `guest add` are in-comprehensive and structured disorderly.

Let's,
* Add more comprehensive testing for the two commands
* Improve differentiability of the tests for the two commands by renaming the test Vendor and Guest object.