### PR TITLE
build.gradle: Enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveFileName = 'wedlog.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
By default, assertions are disabled. This could create a situation where one thinks that all assertions are verified when they in fact are not being checked. According to [the project details](https://nus-cs2103-ay2324s1.github.io/website/schedule/week10/project.html#3-start-the-next-iteration), assertions should be enabled in the gradle file.

Let's modify build.gradle to enable assertions.