### PR TITLE
Fix `guest edit` bug

### DIFF
--- a/src/main/java/wedlog/address/logic/parser/GuestEditCommandParser.java
+++ b/src/main/java/wedlog/address/logic/parser/GuestEditCommandParser.java
@@ -53,8 +53,7 @@ public class GuestEditCommandParser implements Parser<GuestEditCommand> {
         EditGuestDescriptor editGuestDescriptor = new EditGuestDescriptor();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editGuestDescriptor.setName(
-                    ParserUtil.parseIfNotBlank(argMultimap.getValue(PREFIX_NAME).get(), ParserUtil::parseName));
+            editGuestDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
             editGuestDescriptor.setPhone(

--- a/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/wedlog/address/logic/commands/CommandTestUtil.java
@@ -116,6 +116,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String TAG_DESC_FLORIST = " " + PREFIX_TAG + VALID_TAG_FLORIST;
     public static final String TAG_DESC_PHOTOGRAPHER = " " + PREFIX_TAG + VALID_TAG_PHOTOGRAPHER;
+    public static final String INVALID_EMPTY_NAME_DESC = " " + PREFIX_NAME; // empty string not allowed in names
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol

--- a/src/test/java/wedlog/address/logic/parser/GuestEditCommandParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/GuestEditCommandParserTest.java
@@ -8,6 +8,7 @@ import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_GABE;
 import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static wedlog.address.logic.commands.CommandTestUtil.INVALID_EMPTY_NAME_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_RSVP_DESC;
@@ -92,6 +93,7 @@ public class GuestEditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_EMPTY_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email

--- a/src/test/java/wedlog/address/logic/parser/VendorEditCommandParserTest.java
+++ b/src/test/java/wedlog/address/logic/parser/VendorEditCommandParserTest.java
@@ -7,6 +7,7 @@ import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static wedlog.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static wedlog.address.logic.commands.CommandTestUtil.INVALID_EMPTY_NAME_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static wedlog.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -84,6 +85,7 @@ public class VendorEditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_EMPTY_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email


### PR DESCRIPTION
`guest edit` function results in an exception when an empty string is passed as a name value.

Let's,
* Update implementation of `guest edit` to display an error message when provided with an invalid name value.
* Update test cases to detect this bug in the future.