### PR TITLE
Fix minor bug in diet statistics

### DIFF
--- a/src/main/java/wedlog/address/model/person/UniqueGuestList.java
+++ b/src/main/java/wedlog/address/model/person/UniqueGuestList.java
@@ -150,6 +150,10 @@ public class UniqueGuestList implements Iterable<Guest> {
         for (Guest guest : internalList) {
             String dietaryRequirementsString = guest.getDietaryRequirementsString();
 
+            if (guest.getRsvpStatus().status != RsvpStatus.Status.YES) {
+                continue;
+            }
+
             if (dietaryRequirementsString.isEmpty()) {
                 dietaryRequirementsString = "regular";
             }

--- a/src/test/java/wedlog/address/logic/LogicManagerTest.java
+++ b/src/test/java/wedlog/address/logic/LogicManagerTest.java
@@ -11,6 +11,8 @@ import static wedlog.address.logic.commands.CommandTestUtil.PHONE_DESC_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.RSVP_DESC_GIA;
 import static wedlog.address.logic.commands.CommandTestUtil.TABLE_DESC_GIA;
 import static wedlog.address.testutil.Assert.assertThrows;
+import static wedlog.address.testutil.TypicalGuests.GABRIEL;
+import static wedlog.address.testutil.TypicalGuests.GEORGE;
 import static wedlog.address.testutil.TypicalGuests.GIA;
 import static wedlog.address.testutil.TypicalGuests.GINA;
 import static wedlog.address.testutil.TypicalGuests.GREG;
@@ -106,9 +108,11 @@ public class LogicManagerTest {
     public void getDietaryRequirementStatisticsTest() {
         HashMap<String, Integer> expectedMap = new HashMap<>();
         expectedMap.put("vegan", 1);
-        expectedMap.put("none", 1);
+        expectedMap.put("no beef", 1);
         model.addGuest(GINA);
-        model.addGuest(GREG);
+        model.addGuest(GREG); // rsvp no
+        model.addGuest(GABRIEL); // rsvp unknown
+        model.addGuest(GEORGE);
         assertEquals(new DietaryRequirementStatistics(expectedMap), logic.getDietaryRequirementStatistics());
     }
 

--- a/src/test/java/wedlog/address/model/AddressBookTest.java
+++ b/src/test/java/wedlog/address/model/AddressBookTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static wedlog.address.testutil.Assert.assertThrows;
+import static wedlog.address.testutil.TypicalGuests.GABRIEL;
+import static wedlog.address.testutil.TypicalGuests.GEORGE;
 import static wedlog.address.testutil.TypicalGuests.GINA;
 import static wedlog.address.testutil.TypicalGuests.GREG;
 import static wedlog.address.testutil.TypicalPersons.ALICE;
@@ -190,11 +192,13 @@ public class AddressBookTest {
     public void getDietaryRequirementStatisticsTest() {
         HashMap<String, Integer> expectedMap = new HashMap<>();
         expectedMap.put("vegan", 1);
-        expectedMap.put("none", 1);
+        expectedMap.put("no beef", 1);
         DietaryRequirementStatistics expectedDietaryRequirementStatistics =
                 new DietaryRequirementStatistics(expectedMap);
         addressBook.addGuest(GINA);
-        addressBook.addGuest(GREG);
+        addressBook.addGuest(GREG); // rsvp no
+        addressBook.addGuest(GABRIEL); // rsvp unknown
+        addressBook.addGuest(GEORGE);
         assertEquals(expectedDietaryRequirementStatistics, addressBook.getDietaryRequirementStatistics());
     }
 

--- a/src/test/java/wedlog/address/model/ModelManagerTest.java
+++ b/src/test/java/wedlog/address/model/ModelManagerTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static wedlog.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static wedlog.address.testutil.Assert.assertThrows;
+import static wedlog.address.testutil.TypicalGuests.GABRIEL;
 import static wedlog.address.testutil.TypicalGuests.GEORGE;
+import static wedlog.address.testutil.TypicalGuests.GINA;
 import static wedlog.address.testutil.TypicalGuests.GREG;
 import static wedlog.address.testutil.TypicalPersons.ALICE;
 import static wedlog.address.testutil.TypicalPersons.BENSON;
@@ -270,12 +272,14 @@ public class ModelManagerTest {
     @Test
     public void getDietaryRequirementStatisticsTest() {
         HashMap<String, Integer> expectedMap = new HashMap<>();
-        expectedMap.put("none", 1);
+        expectedMap.put("vegan", 1);
         expectedMap.put("no beef", 1);
         DietaryRequirementStatistics expectedDietaryRequirementStatistics =
                 new DietaryRequirementStatistics(expectedMap);
-        modelManager.addGuest(GEORGE);
+        modelManager.addGuest(GINA);
         modelManager.addGuest(GREG);
+        modelManager.addGuest(GABRIEL);
+        modelManager.addGuest(GEORGE);
         assertEquals(expectedDietaryRequirementStatistics, modelManager.getDietaryRequirementStatistics());
     }
 

--- a/src/test/java/wedlog/address/model/person/UniqueGuestListTest.java
+++ b/src/test/java/wedlog/address/model/person/UniqueGuestListTest.java
@@ -7,10 +7,12 @@ import static wedlog.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static wedlog.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static wedlog.address.testutil.Assert.assertThrows;
 import static wedlog.address.testutil.TypicalGuests.GABRIEL;
+import static wedlog.address.testutil.TypicalGuests.GERRARD;
 import static wedlog.address.testutil.TypicalGuests.GIDEON;
 import static wedlog.address.testutil.TypicalGuests.GINA;
 import static wedlog.address.testutil.TypicalGuests.GRACE;
 import static wedlog.address.testutil.TypicalGuests.GREG;
+import static wedlog.address.testutil.TypicalGuests.GREGORY;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -174,9 +176,12 @@ public class UniqueGuestListTest {
         // GINA has dietary requirements "vegan" and rsvp yes
         // GIDEON have dietary requirements "none" and rsvp unknown
         // GREG have dietary requirements "none" and rsvp no
-        // GRACE has dietary requirements "no shellfish" and "no pork" and rsvp yes.
-        expectedMap.put("vegan", 1);
+        // GRACE has dietary requirements "no shellfish" and "no pork" and rsvp yes
+        // GERRARD has no dietary requirements and rsvp yes
+        // GREGORY has dietary requirements "vegan" and rsvp yes
+        expectedMap.put("vegan", 2);
         expectedMap.put("no pork, no shellfish", 1);
+        expectedMap.put("regular", 1);
         DietaryRequirementStatistics expectedDietaryRequirementStatistics =
                 new DietaryRequirementStatistics(expectedMap);
         uniqueGuestList.add(GABRIEL); // rsvp unknown
@@ -184,6 +189,8 @@ public class UniqueGuestListTest {
         uniqueGuestList.add(GINA);
         uniqueGuestList.add(GREG); // rsvp no
         uniqueGuestList.add(GRACE);
+        uniqueGuestList.add(GERRARD);
+        uniqueGuestList.add(GREGORY);
         assert(expectedDietaryRequirementStatistics.equals(uniqueGuestList.getDietaryRequirementStatistics()));
     }
 

--- a/src/test/java/wedlog/address/model/person/UniqueGuestListTest.java
+++ b/src/test/java/wedlog/address/model/person/UniqueGuestListTest.java
@@ -170,20 +170,19 @@ public class UniqueGuestListTest {
     @Test
     public void getDietaryRequirementStatisticsTest() {
         HashMap<String, Integer> expectedMap = new HashMap<>();
-        // GABRIEL has unspecified dietary requirements
-        // GINA has dietary requirements "vegan"
-        // GIDEON and GREG have dietary requirements "none"
-        // GRACE has dietary requirements "no shellfish" and "no pork".
+        // GABRIEL has unspecified dietary requirements and rsvp unknown
+        // GINA has dietary requirements "vegan" and rsvp yes
+        // GIDEON have dietary requirements "none" and rsvp unknown
+        // GREG have dietary requirements "none" and rsvp no
+        // GRACE has dietary requirements "no shellfish" and "no pork" and rsvp yes.
         expectedMap.put("vegan", 1);
-        expectedMap.put("none", 2);
         expectedMap.put("no pork, no shellfish", 1);
-        expectedMap.put("regular", 1);
         DietaryRequirementStatistics expectedDietaryRequirementStatistics =
                 new DietaryRequirementStatistics(expectedMap);
-        uniqueGuestList.add(GABRIEL);
-        uniqueGuestList.add(GIDEON);
+        uniqueGuestList.add(GABRIEL); // rsvp unknown
+        uniqueGuestList.add(GIDEON); // rsvp unknown
         uniqueGuestList.add(GINA);
-        uniqueGuestList.add(GREG);
+        uniqueGuestList.add(GREG); // rsvp no
         uniqueGuestList.add(GRACE);
         assert(expectedDietaryRequirementStatistics.equals(uniqueGuestList.getDietaryRequirementStatistics()));
     }

--- a/src/test/java/wedlog/address/testutil/TypicalGuests.java
+++ b/src/test/java/wedlog/address/testutil/TypicalGuests.java
@@ -54,7 +54,7 @@ public class TypicalGuests {
             .build();
     public static final Guest GRACE = new GuestBuilder().withName("Grace Mueller").withPhone("8482131")
             .withEmail("grace@example.com").withAddress("chicago ave")
-            .withRsvpStatus("unknown").withDietaryRequirements("no shellfish", "no pork").withTableNumber("3")
+            .withRsvpStatus("yes").withDietaryRequirements("no shellfish", "no pork").withTableNumber("3")
             .build();
 
     // Manually added - Guest's details found in {@code CommandTestUtil}

--- a/src/test/java/wedlog/address/testutil/TypicalGuests.java
+++ b/src/test/java/wedlog/address/testutil/TypicalGuests.java
@@ -57,6 +57,16 @@ public class TypicalGuests {
             .withRsvpStatus("yes").withDietaryRequirements("no shellfish", "no pork").withTableNumber("3")
             .build();
 
+    public static final Guest GERRARD = new GuestBuilder().withName("Gerrard Tan").withPhone("91324611")
+            .withEmail("gerrard@example.com").withAddress("chinatown")
+            .withRsvpStatus("yes").withDietaryRequirements().withTableNumber("3")
+            .build();
+
+    public static final Guest GREGORY = new GuestBuilder().withName("Gregory Tan").withPhone("91424611")
+            .withEmail("gregory@example.com").withAddress("tampines ave 3")
+            .withRsvpStatus("yes").withDietaryRequirements("vegan").withTableNumber("3")
+            .build();
+
     // Manually added - Guest's details found in {@code CommandTestUtil}
     public static final Guest GIA = new GuestBuilder().withName(VALID_NAME_GIA).withPhone(VALID_PHONE_GIA)
             .withEmail(VALID_EMAIL_GIA).withAddress(VALID_ADDRESS_GIA).withRsvpStatus(VALID_RSVP_STATUS_GIA)


### PR DESCRIPTION
Dietary statistics currently displays the meal counts of all guests. Guests with empty dietary requirement fields are counted under `regular`.

Let's exclude Guests with `r/unknown` and `r/no` from the dietary statistics, since no meals should be ordered for them.