### PR TITLE
Write better success messages

### DIFF
--- a/src/main/java/wedlog/address/logic/Messages.java
+++ b/src/main/java/wedlog/address/logic/Messages.java
@@ -113,6 +113,10 @@ public class Messages {
             return this;
         }
 
+
+        /**
+         * Appends dietary requirements to the {@code Guest} to be displayed, if they are present.
+         */
         private DisplayBuilder addDietaryRequirements(Set<DietaryRequirement> dietaryRequirements) {
             if (dietaryRequirements.isEmpty()) {
                 return this;
@@ -122,6 +126,9 @@ public class Messages {
             return this;
         }
 
+        /**
+         * Appends tags to the {@code Guest} to be displayed, if they are present.
+         */
         private DisplayBuilder addTags(Set<Tag> tags) {
             if (tags.isEmpty()) {
                 return this;

--- a/src/main/java/wedlog/address/logic/Messages.java
+++ b/src/main/java/wedlog/address/logic/Messages.java
@@ -17,15 +17,15 @@ import wedlog.address.model.tag.Tag;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_NO_PREFIX_FOUND = "No prefix was found in the command! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_INVALID_GUEST_DISPLAYED_INDEX = "The guest index provided is invalid";
-    public static final String MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX = "The vendor index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_GUESTS_LISTED_OVERVIEW = "%1$d guests listed!";
-    public static final String MESSAGE_VENDORS_LISTED_OVERVIEW = "%1$d vendors listed!";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid.";
+    public static final String MESSAGE_INVALID_GUEST_DISPLAYED_INDEX = "The guest index provided is invalid.";
+    public static final String MESSAGE_INVALID_VENDOR_DISPLAYED_INDEX = "The vendor index provided is invalid.";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed.";
+    public static final String MESSAGE_GUESTS_LISTED_OVERVIEW = "%1$d guest(s) listed.";
+    public static final String MESSAGE_VENDORS_LISTED_OVERVIEW = "%1$d vendor(s) listed.";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/wedlog/address/logic/Messages.java
+++ b/src/main/java/wedlog/address/logic/Messages.java
@@ -9,6 +9,7 @@ import wedlog.address.logic.parser.Prefix;
 import wedlog.address.model.person.Guest;
 import wedlog.address.model.person.Person;
 import wedlog.address.model.person.Vendor;
+import wedlog.address.model.tag.DietaryRequirement;
 import wedlog.address.model.tag.Tag;
 
 /**
@@ -62,7 +63,7 @@ public class Messages {
                 .addOptional("Email", guest.getEmail())
                 .addOptional("Address", guest.getAddress())
                 .add("RSVP Status", guest.getRsvpStatus())
-                .add("Dietary Requirements", guest.getDietaryRequirements())
+                .addDietaryRequirements(guest.getDietaryRequirements())
                 .addOptional("Table Number", guest.getTableNumber())
                 .addTags(guest.getTags());
 
@@ -84,7 +85,7 @@ public class Messages {
 
     private static class DisplayBuilder {
         private static final String FIELD_SEPARATOR = ", ";
-        private static final String FIELD_NAME_VALUE_SEPARATOR = ":";
+        private static final String FIELD_NAME_VALUE_SEPARATOR = ": ";
         private final StringBuilder stringBuilder = new StringBuilder();
 
         DisplayBuilder(String objectName) {
@@ -112,7 +113,19 @@ public class Messages {
             return this;
         }
 
+        private DisplayBuilder addDietaryRequirements(Set<DietaryRequirement> dietaryRequirements) {
+            if (dietaryRequirements.isEmpty()) {
+                return this;
+            }
+            stringBuilder.append(FIELD_SEPARATOR).append("Dietary Requirements").append(FIELD_NAME_VALUE_SEPARATOR);
+            dietaryRequirements.forEach(stringBuilder::append);
+            return this;
+        }
+
         private DisplayBuilder addTags(Set<Tag> tags) {
+            if (tags.isEmpty()) {
+                return this;
+            }
             stringBuilder.append(FIELD_SEPARATOR).append("Tags").append(FIELD_NAME_VALUE_SEPARATOR);
             tags.forEach(stringBuilder::append);
             return this;

--- a/src/main/java/wedlog/address/logic/commands/ClearCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import wedlog.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "Address book has been cleared.";
 
 
     @Override

--- a/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestDeleteCommand.java
@@ -23,7 +23,7 @@ public class GuestDeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + GUEST_COMMAND_WORD + " " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_GUEST_SUCCESS = "Deleted Guest: %1$s";
+    public static final String MESSAGE_DELETE_GUEST_SUCCESS = "Deleted guest: %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/wedlog/address/logic/commands/GuestEditCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestEditCommand.java
@@ -60,7 +60,7 @@ public class GuestEditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_GUEST_SUCCESS = "Edited Guest: %1$s";
+    public static final String MESSAGE_EDIT_GUEST_SUCCESS = "Edited guest: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_GUEST = "This guest already exists in the address book.";
 

--- a/src/main/java/wedlog/address/logic/commands/GuestEditCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestEditCommand.java
@@ -62,7 +62,7 @@ public class GuestEditCommand extends Command {
 
     public static final String MESSAGE_EDIT_GUEST_SUCCESS = "Edited guest: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_GUEST = "This guest already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_GUEST = "A guest with this name already exists in WedLog.";
 
     private final Index index;
     private final EditGuestDescriptor editGuestDescriptor;

--- a/src/main/java/wedlog/address/logic/commands/GuestListCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestListCommand.java
@@ -11,7 +11,7 @@ import wedlog.address.model.Model;
 public class GuestListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all Guests";
+    public static final String MESSAGE_SUCCESS = "Listed all Guests.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/wedlog/address/logic/commands/GuestListCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/GuestListCommand.java
@@ -11,7 +11,7 @@ import wedlog.address.model.Model;
 public class GuestListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all Guests.";
+    public static final String MESSAGE_SUCCESS = "Listed all guests.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorDeleteCommand.java
@@ -23,7 +23,7 @@ public class VendorDeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + VENDOR_COMMAND_WORD + " " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted Vendor: %1$s";
+    public static final String MESSAGE_DELETE_VENDOR_SUCCESS = "Deleted vendor: %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/wedlog/address/logic/commands/VendorEditCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorEditCommand.java
@@ -54,7 +54,7 @@ public class VendorEditCommand extends Command {
 
     public static final String MESSAGE_EDIT_VENDOR_SUCCESS = "Edited vendor: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_VENDOR = "This vendor already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_VENDOR = "A vendor with this name already exists in WedLog.";
 
     private final Index index;
     private final EditVendorDescriptor editVendorDescriptor;

--- a/src/main/java/wedlog/address/logic/commands/VendorEditCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorEditCommand.java
@@ -52,7 +52,7 @@ public class VendorEditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_VENDOR_SUCCESS = "Edited Vendor: %1$s";
+    public static final String MESSAGE_EDIT_VENDOR_SUCCESS = "Edited vendor: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_VENDOR = "This vendor already exists in the address book.";
 

--- a/src/main/java/wedlog/address/logic/commands/VendorListCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorListCommand.java
@@ -11,7 +11,7 @@ import wedlog.address.model.Model;
 public class VendorListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all Vendors. ";
+    public static final String MESSAGE_SUCCESS = "Listed all vendors. ";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/wedlog/address/logic/commands/VendorListCommand.java
+++ b/src/main/java/wedlog/address/logic/commands/VendorListCommand.java
@@ -11,7 +11,7 @@ import wedlog.address.model.Model;
 public class VendorListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all Vendors";
+    public static final String MESSAGE_SUCCESS = "Listed all Vendors. ";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/wedlog/address/model/tag/DietaryRequirement.java
+++ b/src/main/java/wedlog/address/model/tag/DietaryRequirement.java
@@ -55,7 +55,7 @@ public class DietaryRequirement {
 
     @Override
     public String toString() {
-        return value;
+        return '[' + value + ']';
     }
 
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -58,7 +58,7 @@
             <Insets bottom="6" left="6" right="6"/>
           </padding>
           <VBox minWidth="400.0" prefWidth="10000" VBox.vgrow="ALWAYS">
-            <StackPane fx:id="resultDisplayPlaceholder" minHeight="120.0" styleClass="card" VBox.vgrow="ALWAYS">
+            <StackPane fx:id="resultDisplayPlaceholder" minHeight="80.0" styleClass="card" VBox.vgrow="ALWAYS">
               <padding>
                 <Insets bottom="5" left="10" right="10" top="5" />
               </padding>

--- a/src/test/java/wedlog/address/model/tag/DietaryRequirementTest.java
+++ b/src/test/java/wedlog/address/model/tag/DietaryRequirementTest.java
@@ -38,6 +38,6 @@ public class DietaryRequirementTest {
 
     @Test
     public void toString_returnsCorrectString() {
-        assertEquals(new DietaryRequirement("vegan").toString(), "vegan");
+        assertEquals(new DietaryRequirement("vegan").toString(), "[vegan]");
     }
 }


### PR DESCRIPTION
- [x] add space after colon for guest and vendor fields
- [x] omit `Dietary Requirements:` and `Tags:` when the fields are empty
- [x] standardize punctuation
- [x] standardize capitalization of `Guest` and `Vendor`