### PR TITLE
Name: Make name equality case insensitive

### DIFF
--- a/src/main/java/wedlog/address/model/person/Name.java
+++ b/src/main/java/wedlog/address/model/person/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.toLowerCase().equals(otherName.fullName.toLowerCase());
     }
 
     @Override

--- a/src/test/java/wedlog/address/model/person/NameTest.java
+++ b/src/test/java/wedlog/address/model/person/NameTest.java
@@ -56,5 +56,8 @@ public class NameTest {
 
         // different values -> returns false
         assertFalse(name.equals(new Name("Other Valid Name")));
+
+        // different case -> returns true
+        assertTrue(name.equals(new Name("valid name")));
     }
 }

--- a/src/test/java/wedlog/address/model/person/PersonTest.java
+++ b/src/test/java/wedlog/address/model/person/PersonTest.java
@@ -74,7 +74,7 @@ public class PersonTest {
 
         // name differs in case, all other attributes same -> returns false
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";

--- a/src/test/java/wedlog/address/model/person/VendorTest.java
+++ b/src/test/java/wedlog/address/model/person/VendorTest.java
@@ -91,7 +91,7 @@ public class VendorTest {
         // name differs in case, all other attributes same -> returns false
         Name name2 = new Name("ABC CATERING");
         editedVendor = new Vendor(name2, phone, email, address, tags);
-        assertFalse(vendor.isSamePerson(editedVendor));
+        assertTrue(vendor.isSamePerson(editedVendor));
 
         // name has trailing spaces, all other attributes same -> returns false
         Name name3 = new Name("ABC Catering ");


### PR DESCRIPTION
Name is case sensitive, which means that two names like `John` and `john` are considered different names.

This is inconsistent with other sections of the code base, such as the `GuestFilterCommand` which is case-insensitive. It is also unintuitive.

Let's update the equality of name to be case insensitive.

This will also update the functionality of Person#isSamePerson, preventing users from adding two users with full names that only differ in case.