### PR TITLE
Fix table number max int bug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -568,7 +568,7 @@ Acceptable values for `d/DIETARY_REQUIREMENT`:
 - Alphanumeric word with or without spaces.
 
 Acceptable values for `tn/TABLE_NUMBER`:
-- Non-negative integer with no spaces or special characters.
+- Numbers between 1 and 2147483647 inclusive with no spaces or special characters
 - Preceding zeros will be trimmed.
 - Error message for invalid table numbers: "Table numbers should be positive numbers with no spaces or special characters."
 

--- a/src/main/java/wedlog/address/model/person/TableNumber.java
+++ b/src/main/java/wedlog/address/model/person/TableNumber.java
@@ -3,6 +3,7 @@ package wedlog.address.model.person;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 import static wedlog.address.commons.util.AppUtil.checkArgument;
+import static wedlog.address.commons.util.StringUtil.isNonZeroUnsignedInteger;
 
 /**
  * Represents a Person's table number in the address book.
@@ -31,7 +32,7 @@ public class TableNumber {
      * Returns true if a given string is a valid table number.
      */
     public static boolean isValidTableNumber(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && isNonZeroUnsignedInteger(test);
     }
 
     @Override

--- a/src/test/java/wedlog/address/model/person/TableNumberTest.java
+++ b/src/test/java/wedlog/address/model/person/TableNumberTest.java
@@ -40,7 +40,6 @@ public class TableNumberTest {
         assertTrue(TableNumber.isValidTableNumber("0002"));
         assertTrue(TableNumber.isValidTableNumber("130"));
         assertTrue(TableNumber.isValidTableNumber("2147483647")); // equals to Integer.MAX_VALUE
-
     }
 
     @Test

--- a/src/test/java/wedlog/address/model/person/TableNumberTest.java
+++ b/src/test/java/wedlog/address/model/person/TableNumberTest.java
@@ -32,13 +32,15 @@ public class TableNumberTest {
         assertFalse(TableNumber.isValidTableNumber("9312 1534")); // spaces within digits
         assertFalse(TableNumber.isValidTableNumber("-1")); // special character
         assertFalse(TableNumber.isValidTableNumber("1.1")); //special character
+        assertFalse(TableNumber.isValidTableNumber("2147483648")); // greater than Integer.MAX_VALUE
+        assertFalse(TableNumber.isValidTableNumber("0")); //zero
+        assertFalse(TableNumber.isValidTableNumber("0000")); //zero
 
         // valid table numbers
-        assertTrue(TableNumber.isValidTableNumber("0"));
-        assertTrue(TableNumber.isValidTableNumber("0000"));
         assertTrue(TableNumber.isValidTableNumber("0002"));
         assertTrue(TableNumber.isValidTableNumber("130"));
-        assertTrue(TableNumber.isValidTableNumber("124293842033123")); // long table numbers
+        assertTrue(TableNumber.isValidTableNumber("2147483647")); // equals to Integer.MAX_VALUE
+
     }
 
     @Test


### PR DESCRIPTION
Resolves #212 

* Resolves bug that causes an exception to be thrown when an integer greater than `Integer.MAX_VALUE` is input as the table number for a guest.
* Adds test cases for `isValidTableNumber` method to check that an integer greater than `Integer.MAX_VALUE` is an invalid table number.
* Updates UG  to specify additional constraints on valid table numbers (must be between 1 and 2147483647 inclusive)