### PR TITLE
Fix window size on startup bug

### DIFF
--- a/src/main/java/wedlog/address/commons/core/GuiSettings.java
+++ b/src/main/java/wedlog/address/commons/core/GuiSettings.java
@@ -12,7 +12,7 @@ import wedlog.address.commons.util.ToStringBuilder;
  */
 public class GuiSettings implements Serializable {
 
-    private static final double DEFAULT_HEIGHT = 800;
+    private static final double DEFAULT_HEIGHT = 660;
     private static final double DEFAULT_WIDTH = 1200;
 
     private final double windowWidth;


### PR DESCRIPTION
Resolves #241 

Reduces the default height to 660 so that app window will be fully within the screen on startup. 